### PR TITLE
Add a reproducible benchmark of multi-node bandwidth

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,29 @@
+# Multi-node NCCL Benchmark
+
+Simple NCCL bandwidth benchmark for Modal's multi-node training infrastructure. This benchmark measures the all-reduce performance between nodes using a large tensor (500000x2000 float32), in order to understand the communication performance of your multi-node setup.
+
+## Usage
+
+**2 x 8 x H100, multi-node:**
+
+```bash
+modal run main.py
+```
+
+## Performance Metrics
+
+The benchmark reports two key metrics:
+
+- **algbw (Algorithm Bandwidth)**: The effective bandwidth from the application's perspective
+- **busbw (Bus Bandwidth)**: The actual hardware bandwidth utilization
+
+For more details on these metrics, see the [NVIDIA NCCL Tests documentation](https://github.com/NVIDIA/nccl-tests/blob/master/doc/PERFORMANCE.md#bandwidth).
+
+## Environment Configuration
+
+The benchmark automatically configures RDMA settings for OCI's infrastructure:
+
+- Uses IPv6 for control plane (TCP) communication
+- Uses IPv4 for data plane (RDMA) communication
+- Configures optimal NCCL parameters for IB/RDMA
+- Sets appropriate HCA device ordering

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -1,0 +1,84 @@
+import os
+
+import torch
+import torch.distributed as dist
+
+# Default settings from EleutherAI cookbook
+WARMUP_ITERS, TRIALS = 5, 50
+
+# these emulate the payload which will become a M * N * 4-sized tensor below
+N = 500000
+M = 2000
+
+
+def sync_all():
+    torch.cuda.synchronize()
+    dist.barrier()
+
+
+def timed_allreduce(mat, start_event, end_event, warmup_iters, iters):
+    sync_all()
+    for _ in range(warmup_iters):
+        dist.all_reduce(mat)
+    sync_all()
+
+    start_event.record()
+    for _ in range(iters):
+        dist.all_reduce(mat)
+    end_event.record()
+
+    sync_all()
+    duration = start_event.elapsed_time(end_event) / 1000
+    avg_duration = duration / iters
+
+    n = dist.get_world_size()
+    size = M * N * 4  # 4 is 4 bytes in fp32
+    # note that this is following the same math as NVIDIA/nccl-tests
+    algbw = torch.tensor([size / avg_duration]).cuda(local_rank)
+
+    # calculate mean across all ranks
+    dist.reduce(algbw, dst=0, op=dist.ReduceOp.SUM)
+    algbw /= n
+
+    return algbw.item()
+
+
+def run(local_rank):
+    is_global_rank_0 = dist.get_rank() == 0
+
+    mat = torch.rand(N, M, dtype=torch.float32).cuda(local_rank)
+
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+
+    algbw = timed_allreduce(mat, start_event, end_event, warmup_iters=WARMUP_ITERS, iters=TRIALS)
+
+    # the 2*(n-1)/n busbw correction factor specific to all-reduce is explained here:
+    # https://github.com/NVIDIA/nccl-tests/blob/master/doc/PERFORMANCE.md#allreduce
+    # busbw reflects how optimally the hardware is used
+    n = dist.get_world_size()
+    busbw = algbw * (2 * (n - 1) / n)
+
+    if is_global_rank_0:
+        print(
+            f"The average bandwidth of all_reduce with a {M * N * 4 / 1e9}GB payload ({TRIALS} trials, {n} ranks):\n",
+            f"algbw: {algbw / 1e9:.3f} GBps ({algbw * 8 / 1e9:.1f} Gbps)\n",
+            f"busbw: {busbw / 1e9:.3f} GBps ({busbw * 8 / 1e9:.1f} Gbps)\n",
+        )
+
+
+def init_processes(local_rank, fn, backend="nccl"):
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group(backend, device_id=torch.device(f"cuda:{local_rank}"))
+    if dist.get_rank() == 0:
+        print("Starting benchmark...")
+
+    fn(local_rank)
+
+    sync_all()
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    local_rank = int(os.environ["LOCAL_RANK"])
+    init_processes(local_rank=local_rank, fn=run)

--- a/benchmark/main.py
+++ b/benchmark/main.py
@@ -1,0 +1,102 @@
+import os
+
+import modal
+import modal.experimental
+
+cuda_version = "12.4.0"  # should be no greater than host CUDA version
+flavor = "devel"  #  includes full CUDA toolkit
+operating_sys = "ubuntu22.04"
+tag = f"{cuda_version}-{flavor}-{operating_sys}"
+
+LOCAL_CODE_DIR = os.path.dirname(os.path.abspath(__file__))
+REMOTE_CODE_DIR = "/root/"
+REMOTE_BENCH_SCRIPT_PATH = "/root/benchmark.py"
+
+N_NODES = 2
+N_PROC_PER_NODE = 8
+
+image = (
+    modal.Image.from_registry(f"nvidia/cuda:{tag}", add_python="3.12")
+    .apt_install(
+        "libibverbs-dev",
+        "libibverbs1",
+    )
+    .pip_install(
+        "torch",
+        "numpy",
+        "importlib-metadata",
+    )
+    .add_local_dir(
+        LOCAL_CODE_DIR,
+        remote_path=REMOTE_CODE_DIR,
+    )
+)
+
+app = modal.App("multinode-benchmark")
+
+
+def export_rdma_env():
+    os.environ["LD_LIBRARY_PATH"] = (
+        f"{os.environ.get('LD_LIBRARY_PATH', '')}:/usr/local/lib"
+    )
+    os.environ["NCCL_DEBUG"] = "INFO"
+    os.environ["LOGLEVEL"] = "DEBUG"
+    os.environ["NCCL_IB_SPLIT_DATA_ON_QPS"] = "0"
+    os.environ["NCCL_IB_QPS_PER_CONNECTION"] = "4"
+    os.environ["NCCL_IB_TC"] = "41"
+    os.environ["NCCL_IB_SL"] = "0"
+    os.environ["NCCL_IB_TIMEOUT"] = "22"
+
+    # Control‑plane (TCP) — stays on eth1, uses IPv6
+    os.environ["NCCL_SOCKET_IFNAME"] = "eth1"
+    os.environ["NCCL_SOCKET_FAMILY"] = "AF_INET6"
+
+    # Data‑plane (RDMA) — stays on the HCA ports, uses IPv4
+    os.environ["NCCL_IB_ADDR_FAMILY"] = "AF_INET"
+    os.environ["NCCL_IB_GID_INDEX"] = "3"  # OCI's IPv4‑mapped GID index
+    os.environ["NCCL_IB_HCA"] = (
+        "=mlx5_1,mlx5_2,mlx5_3,mlx5_4,mlx5_5,mlx5_6,mlx5_7,mlx5_8,mlx5_14,mlx5_15,mlx5_16,mlx5_17,mlx5_9,mlx5_10,mlx5_11,mlx5_12"
+    )
+    os.environ["NCCL_IB_MERGE_NICS"] = "0"
+
+
+@app.function(
+    gpu="H100:8",
+    cloud="oci",
+    region="us-chicago-1",
+    image=image,
+    experimental_options={"rdma_enabled": "1"},
+)
+@modal.experimental.clustered(size=N_NODES)
+def run_benchmark():
+    """Run a simple benchmark script that passes around a tensor of size 500000x2000."""
+
+    from torch.distributed.run import parse_args, run
+
+    export_rdma_env()
+
+    cluster_info = modal.experimental.get_cluster_info()
+    # which container am I?
+    container_rank: int = cluster_info.rank
+    # what's the leader/master/main container's address?
+    main_ip_addr: str = cluster_info.container_ips[0]
+    container_id = os.environ["MODAL_TASK_ID"]
+
+    print(f"hello from {container_id}, rank {container_rank} of {N_NODES}")
+    if container_rank == 0:
+        print(f"main container's address: {main_ip_addr}")
+
+    args = [
+        f"--nnodes={N_NODES}",
+        f"--nproc-per-node={N_PROC_PER_NODE}",
+        f"--node-rank={cluster_info.rank}",
+        f"--master-addr={main_ip_addr}",
+        REMOTE_BENCH_SCRIPT_PATH,
+    ]
+    print(f"Running torchrun with args: {' '.join(args)}")
+    run(parse_args(args))
+
+
+@app.local_entrypoint()
+def main():
+    run_benchmark.remote()


### PR DESCRIPTION
This allows our users to test that multi-node is working at full bandwidth:

```
The average bandwidth of all_reduce with a 4.0GB payload (50 trials, 16 ranks):
 algbw: 180.776 GBps (1446.2 Gbps)
 busbw: 338.955 GBps (2711.6 Gbps)
```