### PR TITLE
Clean up benchmark and nanogpt rdma usage according to new changes

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -7,7 +7,7 @@ Simple NCCL bandwidth benchmark for Modal's multi-node training infrastructure. 
 **2 x 8 x H100, multi-node:**
 
 ```bash
-modal run main.py
+modal run modal_train.py
 ```
 
 ## Performance Metrics

--- a/nanoGPT/modal_train.py
+++ b/nanoGPT/modal_train.py
@@ -47,38 +47,6 @@ n_nodes = 2
 # Typically this matches the number of GPUs per container.
 n_proc_per_node = 8
 
-rdma_scheduling_constraints = {
-    "cloud": "oci",
-    "region": "us-chicago-1",
-    "experimental_options": {
-        "rdma_enabled": "1",
-    },
-}
-
-
-def export_rdma_env():
-    os.environ["LD_LIBRARY_PATH"] = (
-        f"{os.environ.get('LD_LIBRARY_PATH', '')}:/usr/local/lib"
-    )
-    os.environ["NCCL_DEBUG"] = "INFO"
-    os.environ["LOGLEVEL"] = "DEBUG"
-    os.environ["NCCL_IB_SPLIT_DATA_ON_QPS"] = "0"
-    os.environ["NCCL_IB_QPS_PER_CONNECTION"] = "4"
-    os.environ["NCCL_IB_TC"] = "41"
-    os.environ["NCCL_IB_SL"] = "0"
-    os.environ["NCCL_IB_TIMEOUT"] = "22"
-
-    # Control‑plane (TCP) — stays on eth1, uses IPv6
-    os.environ["NCCL_SOCKET_IFNAME"] = "eth1"
-    os.environ["NCCL_SOCKET_FAMILY"] = "AF_INET6"
-
-    # Data‑plane (RDMA) — stays on the HCA ports, uses IPv4
-    os.environ["NCCL_IB_ADDR_FAMILY"] = "AF_INET"
-    os.environ["NCCL_IB_GID_INDEX"] = "3"  # OCI's IPv4‑mapped GID index
-    os.environ["NCCL_IB_HCA"] = (
-        "mlx5_0,mlx5_1,mlx5_3,mlx5_4,mlx5_5,mlx5_6,mlx5_7,mlx5_8,mlx5_9,mlx5_10,mlx5_12,mlx5_13,mlx5_14,mlx5_15,mlx5_16,mlx5_17"
-    )
-
 
 @app.function(
     timeout=3600,
@@ -187,8 +155,6 @@ def speedrun_modded_single_node():
 def _train_multi_node() -> None:
     from torch.distributed.run import parse_args, run
 
-    export_rdma_env()
-
     cluster_info = modal.experimental.get_cluster_info()
     # which container am I?
     container_rank: int = cluster_info.rank
@@ -226,9 +192,9 @@ def _train_multi_node() -> None:
         "/root/out": volume_model_output,
     },
     timeout=60 * 60 * 24,
-    **rdma_scheduling_constraints,
+    cloud="oci",
 )
-@modal.experimental.clustered(n_nodes)
+@modal.experimental.clustered(n_nodes, rdma=True)
 def train_multi_node():
     """
     Train the model on a multi-node cluster with N GPUs per node (typically 8).
@@ -246,9 +212,9 @@ def train_multi_node():
         "/root/out": volume_model_output,
     },
     timeout=60 * 60 * 24,
-    **rdma_scheduling_constraints,
+    cloud="oci",
 )
-@modal.experimental.clustered(n_nodes)
+@modal.experimental.clustered(n_nodes, rdma=True)
 def bench_multi_node():
     """
     Train the model on a multi-node cluster with N GPUs per node (typically 8).
@@ -269,9 +235,9 @@ def bench_multi_node():
         "/root/out": volume_model_output,
     },
     timeout=2 * 60 * 60,  # should always be faster than 2 hours
-    **rdma_scheduling_constraints,
+    cloud="oci",
 )
-@modal.experimental.clustered(n_nodes)
+@modal.experimental.clustered(n_nodes, rdma=True)
 def speedrun_multi_node():
     """
     Follow https://github.dev/KellerJordan/modded-nanogpt's benchmark rules to test


### PR DESCRIPTION
We pushed these env vars into the worker, and we pushed `rdma=True` into a proper client variable.