### PR TITLE
pin deps in imagenet downloader

### DIFF
--- a/resnet50/imagenet_download.py
+++ b/resnet50/imagenet_download.py
@@ -6,7 +6,7 @@ app = modal.App(
     "imagenet-download",
     image=(
         modal.Image.debian_slim()
-        .pip_install("webdataset", "huggingface_hub[cli]", "hf_transfer")
+        .pip_install("webdataset==0.2.111", "huggingface_hub[cli]==0.31.4", "hf_transfer==0.1.9")
         .env({"HF_HUB_ENABLE_HF_TRANSFER": "1"})
         .add_local_python_source("imagenet_classes")
     ),


### PR DESCRIPTION
We should ensure this is done everywhere in the guide. It's a checklist item in the examples repo. Sloppy otherwise. 