### PR TITLE
Remove MFU calculation for speedruns, achieving new speedrun record

### DIFF
--- a/nanoGPT/README.md
+++ b/nanoGPT/README.md
@@ -9,10 +9,10 @@ GPU configurations:
 | GPU Config | Time per iteration | MFU |
 |------------|-------------------|-----|
 | 8xA100 | ~360ms | ~47.84% |
-| 8xH100 | ~230ms | ~25.4% |
-| 8xH200 | ~220ms | ~25.0% |
-| 2x8xH100 | 250-350ms | ~23.5% |
-| 4x8xH100 | ~180-200ms | ~17% |
+| 8xH100 | ~231ms | ~25.4% |
+| 8xH200 | ~225ms | ~25.0% |
+| 2x8xH100 | ~121ms | ~24.2% |
+| 4x8xH100 | ~63ms | ~23.3% |
 
 ### NanoGPT Speedrun Performance
 
@@ -22,8 +22,8 @@ GPU configurations:
 | Modal nanoGPT (this repo) | 1 | 8x A100 80BG SXM | 2025-02-16 | 45.62 mins | 0.99x |
 | Modal nanoGPT (this repo) | 1 | 8x H100 SXM | 2025-02-16 | 24.93 mins | 1.805x
 | Modal nanoGPT (this repo) | 1 | 8x H**2**00 SXM | 2025-02-16 | 23.97 mins | 1.88x |
-| Modal clustered nanoGPT (this repo) | 2 | 2x8xH100 SXM | 2025-04-23 | 16.1 mins | 2.79x |
-| Modal clustered nanoGPT (this repo) | 4 | 4x8xH100 SXM | 2025-04-23 | 11 mins | 4.09x | 
+| Modal clustered nanoGPT (this repo) | 2 | 2x8xH100 SXM | 2025-04-23 | 10.54 mins | 4.32x |
+| Modal clustered nanoGPT (this repo) | 4 | 4x8xH100 SXM | 2025-04-23 | 5.88 mins | 7.65x | 
 | [modded-nanogpt](https://github.dev/KellerJordan/modded-nanogpt) at `64d8eb51` | 1 | 8x H100 SXM | 2025-02-01 | 2.997 mins | 15.01x |
 | [modded-nanogpt](https://github.dev/KellerJordan/modded-nanogpt) at `64d8eb51` (on Modal, `gvisor`) | 1 | 8x H100 SXM | 2025-04-12 | 3.229 mins | 13.93x |
 <!--| [modded-nanogpt](https://github.dev/KellerJordan/modded-nanogpt) at `64d8eb51` (on Modal, legacy runtime) | 1 | 8x H100 SXM | 2025-04-12 | 3.03 mins | 14.85x | -->

--- a/nanoGPT/modal_train.py
+++ b/nanoGPT/modal_train.py
@@ -101,7 +101,7 @@ def train_single_node():
 
 
 @app.function(
-    gpu=f"H100:{n_proc_per_node}",
+    gpu=f"H100!:{n_proc_per_node}",
     volumes={
         "/vol": volume,
         # Mount a Volume where NanoGPT outputs checkpoints.
@@ -227,6 +227,7 @@ def bench_multi_node():
     # Enable profiling.
     os.environ["NANOGPT_MAX_ITERS"] = "200"
     os.environ["NANOGPT_PROFILE"] = "true"
+    os.environ["NANOGPT_BENCH"] = "true"
     _train_multi_node()
 
 


### PR DESCRIPTION
This MFU calculation was slowing down multi-node runs significantly. For some reason, this didn't have the same effect on single-node runs. I re-ran them but got similar results, so I didn't update them.
## Checklist

- [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [x] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`

(Modal's internal guide page for this repo is _Multi-node examples guidance_.)
