### PR TITLE
Cache flops promised, fixing mfu estimation lag

### DIFF
--- a/nanoGPT/train.py
+++ b/nanoGPT/train.py
@@ -462,9 +462,7 @@ with profiler:
 
             out_str = f"iter {iter_num}: loss {lossf:.4f}, time {dt * 1000:.2f}ms"
 
-            # MFU calculation takes a ~70ms hit, so only do it if we're benchmarking.
-            # TODO(pawalt): figure out why mfu calculation is so expensive
-            if bench and local_iter_num >= 5:
+            if local_iter_num >= 5:
                 mfu = raw_model.estimate_mfu(
                     batch_size * gradient_accumulation_steps, dt
                 )


### PR DESCRIPTION
Not sure how I missed this one, but MFU estimation is now accurate:

```
iter 64: loss 8.6740, time 119.74ms, mfu 35.40%
iter 65: loss 8.6446, time 119.72ms, mfu 35.41%
iter 66: loss 8.6629, time 119.94ms, mfu 35.41%
iter 67: loss 8.7104, time 120.16ms, mfu 35.40%
```