### PR TITLE
Pin multinode scripts to use torch 2.6.0

### DIFF
--- a/benchmark/modal_train.py
+++ b/benchmark/modal_train.py
@@ -22,7 +22,7 @@ image = (
         "libibverbs1",
     )
     .pip_install(
-        "torch",
+        "torch==2.6.0",
         "numpy",
         "importlib-metadata",
     )

--- a/nanoGPT/modal_train.py
+++ b/nanoGPT/modal_train.py
@@ -28,7 +28,14 @@ base_image = (
     # ref: https://github.com/astral-sh/uv/issues/6437#issuecomment-2535324784
     .apt_install("git", "libibverbs-dev", "libibverbs1")
     # https://github.com/karpathy/nanoGPT?tab=readme-ov-file#install
-    .pip_install("torch==2.7.0", "transformers==4.51.3", "datasets==3.6.0", "tiktoken==0.9.0", "wandb==0.19.11", "tqdm==4.67.1")
+    .pip_install(
+        "torch==2.6.0",
+        "transformers==4.51.3",
+        "datasets==3.6.0",
+        "tiktoken==0.9.0",
+        "wandb==0.19.11",
+        "tqdm==4.67.1",
+    )
 )
 image = base_image.add_local_dir(
     LOCAL_CODE_DIR,


### PR DESCRIPTION
2.7.0 has a NCCL deadlock, so we should only upgrade once a fix is released.
