### PR TITLE
Don't forward training TP/PP into checkpoint conversion

### DIFF
--- a/slime/modal_helpers/utils.py
+++ b/slime/modal_helpers/utils.py
@@ -61,12 +61,11 @@ def get_checkpoint_conversion_policy(slime_cfg) -> tuple[int, int, list[str]]:
         if nproc_per_node > gpus_per_node:
             continue
 
+        # Don't forward training TP/PP into conversion. slime's converter runs
+        # TP=1 and auto-shards by pipeline (PP = world_size); forwarding TP>1 with
+        # PP=1 makes TP*PP exceed world_size and trips Megatron's validate_args.
+        # The torch_dist output is reshardable, so the conversion layout is irrelevant.
         extra_args: list[str] = []
-        if tp > 1 or pp > 1:
-            extra_args += [
-                f"--tensor-model-parallel-size {tp}",
-                f"--pipeline-model-parallel-size {pp}",
-            ]
         for attr, flag in _CONVERSION_EXTRA_ARGS:
             if x := getattr(slime_cfg, attr, None):
                 extra_args.append(f"--{flag} {x}")


### PR DESCRIPTION
The dapo recipe for slime (qwen3_dapo) fails the checkpoint conversion. 

## Summary
- HF→Megatron conversion crashed for configs with TP>1 and PP=1 (e.g. Qwen3-30B-A3B at TP=4) with `world size (4) is not divisible by total_model_size (total_model_size=16)`.
- Root cause: `get_checkpoint_conversion_policy` forwarded the training TP/PP into the converter, but slime's `convert_hf_to_torch_dist.py` expects TP=1 and force-sets `PP = world_size` whenever `PP == 1`. That turned TP=4 + auto-PP=4 into `total_model_size=16` while only 4 GPUs were launched, failing Megatron's `validate_args`.
- Fix: stop emitting `--tensor-model-parallel-size` / `--pipeline-model-parallel-size` for conversion and let the converter shard purely by pipeline. `world_size = tp * pp` is kept (it sets the GPU/memory budget). The `torch_dist` output is reshardable, so the conversion layout is independent of the training layout.

## Test plan
- did`modal run slime/modal_train.py::convert_hf_to_megatron_checkpoint` for a TP>1/PP=1 config (e.g. `w_qwen3_dapo`) completes and writes the torch_dist checkpoint.
- Subsequent `train` run loads the converted checkpoint (resharded to TP=4/PP=1/EP=8) without error.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-labs/multinode-training-guide/pull/86" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->