### PR TITLE
NemoRL multinode training example

### DIFF
--- a/nemo-rl/README.md
+++ b/nemo-rl/README.md
@@ -1,0 +1,136 @@
+# nemo-rl — Modal launcher for NeMo-RL training
+
+Thin Modal launcher that runs [NeMo-RL](https://github.com/NVIDIA-NeMo/RL) RL
+training (GRPO, SFT, DPO, …) on multi-node Modal GPU clusters.
+
+It mirrors the [`slime/`](../slime) launcher in this repo: each experiment is a
+Python config, a clustered Modal function brings up a Ray cluster across the
+allocation, and the driver runs on the head node. The difference is that NeMo-RL
+is driven by a YAML config plus Hydra `key=value` overrides rather than raw CLI
+flags.
+
+## Prerequisites
+
+- Modal CLI installed and authenticated
+- Modal environment selected: `export MODAL_ENVIRONMENT=<your-env>`
+- Modal secrets:
+  - `huggingface-secret` — `HF_TOKEN` for model/data download (gated models)
+  - `wandb-secret` — `WANDB_API_KEY` for configs with `logger.wandb_enabled=true`
+
+Run all commands from this directory (`nemo-rl/`).
+
+## Common Workflow
+
+Set the config name once:
+
+```bash
+export EXPERIMENT_CONFIG=qwen2_5_1_5b_math
+```
+
+List available configs:
+
+```bash
+modal run modal_train.py::list_configs
+```
+
+Download the model into the HF cache volume:
+
+```bash
+modal run modal_train.py::download_model
+```
+
+Download dataset: 
+
+```bash
+modal run modal_train.py::download_data
+```
+
+Launch training:
+
+```bash
+modal run -d modal_train.py::train
+```
+
+Use `-d` (detached) to keep training running after you close your terminal. The
+Ray dashboard URL is printed at the start of the run.
+
+## Launcher Model
+
+Each experiment lives in `configs/<name>.py` and exposes:
+
+- `modal`: `ModalConfig` for image, GPU type, and Modal resources
+- `nemo_rl`: `NemoRLConfig` for the recipe (run script, base YAML, cluster
+  shape, and Hydra overrides)
+
+The launcher runs this on the Ray head node:
+
+```bash
+cd /opt/nemo-rl && uv run python <entrypoint> --config <base_config> <overrides...>
+```
+
+### How multi-node works
+
+1. `train` is wrapped in `modal.experimental.clustered(num_nodes, rdma=True)`,
+   so Modal provisions `num_nodes` RDMA-connected GPU nodes.
+2. Each node reads its rank from `modal.experimental.get_cluster_info()`.
+3. Rank 0 starts the Ray head and waits until all nodes and GPUs have joined;
+   ranks 1…N start Ray workers pointed at the head and idle.
+4. Rank 0 runs the NeMo-RL driver, which attaches to the existing Ray cluster
+   (`RAY_ADDRESS`) and schedules its actors across the whole allocation.
+
+This is the equivalent of NemoRL's Slurm script [`ray.sub`](https://github.com/NVIDIA-NeMo/RL/blob/main/ray.sub).
+
+## Volumes
+
+| Volume | Mount path | Purpose |
+| --- | --- | --- |
+| `huggingface-cache` | `/root/.cache/huggingface` | HF model + dataset cache |
+| `nemo-rl-checkpoints` | `/checkpoints` | Training checkpoints |
+
+## Add A Config
+
+Create `configs/<name>.py`:
+
+```python
+from configs.base import ModalConfig, NemoRLConfig
+
+modal = ModalConfig(gpu="H100")
+
+
+class _Recipe(NemoRLConfig):
+    entrypoint = "examples/run_grpo.py"
+    base_config = "examples/configs/grpo_math_8B.yaml"
+
+    num_nodes = 2
+    gpus_per_node = 8
+
+    hf_model = "meta-llama/Llama-3.1-8B-Instruct"
+    hf_datasets = ["nvidia/OpenMathInstruct-2"]
+
+    overrides = {
+        "policy.model_name": "meta-llama/Llama-3.1-8B-Instruct",
+        "policy.dtensor_cfg.tensor_parallel_size": 8,
+        "logger.wandb_enabled": True,
+        "logger.wandb.name": "my-run",
+    }
+
+
+nemo_rl = _Recipe()
+```
+
+The base_config points to a path in the NemoRL repo under examples/configs 
+## Dev overlay
+
+To run local NeMo-RL changes without rebuilding the image, point `local_nemo_rl`
+at your checkout. It is copied over `/opt/nemo-rl` in the image:
+
+```python
+modal = ModalConfig(
+    gpu="H100",
+    local_nemo_rl="/path/to/your/RL",
+)
+```
+
+The container still uses its baked `/opt/nemo_rl_venv`, so this only overlays
+source code, not dependencies. If you change dependencies, rebuild/extend the
+image (e.g. via `image_run_commands`).

--- a/nemo-rl/configs/__init__.py
+++ b/nemo-rl/configs/__init__.py
@@ -1,0 +1,17 @@
+import importlib
+from pathlib import Path
+
+_CONFIGS_DIR = Path(__file__).parent
+_SKIP = {"base", "__init__"}
+
+
+def get_module(name: str):
+    try:
+        return importlib.import_module(f"configs.{name}")
+    except ModuleNotFoundError as exc:
+        if exc.name != f"configs.{name}":
+            raise
+        available = sorted(
+            f.stem for f in _CONFIGS_DIR.glob("*.py") if f.stem not in _SKIP
+        )
+        raise ValueError(f"Unknown config {name!r}. Available: {available}") from exc

--- a/nemo-rl/configs/base.py
+++ b/nemo-rl/configs/base.py
@@ -1,0 +1,161 @@
+"""Base configuration classes and volume mount paths for NeMo-RL.
+
+Two separate concerns:
+
+  ModalConfig  — Modal infrastructure (gpu model, image, dev overlay)
+  NemoRLConfig — NeMo-RL recipe: which run script, which base YAML config,
+                 cluster shape, and Hydra overrides
+
+NeMo-RL is driven by a YAML config plus Hydra-style ``key=value`` overrides
+(see ``examples/run_grpo.py``). Unlike slime — where every config attribute
+becomes a CLI flag — NeMo-RL configs carry a single ``overrides`` dict of
+dotted Hydra keys, because the keys contain dots that are not valid Python
+attribute names.
+
+Each experiment defines one ``ModalConfig`` and one ``NemoRLConfig`` instance.
+"""
+
+from pathlib import Path
+from typing import Any, Literal
+
+# ── Volume mount paths ────────────────────────────────────────────────────────
+
+# The NeMo-RL container caches Hugging Face artifacts under the default HF home.
+HF_CACHE_PATH = Path("/root/.cache/huggingface")
+CHECKPOINTS_PATH = Path("/checkpoints")
+
+# Where the NeMo-RL repo lives inside the official image (see docker/Dockerfile).
+NEMO_RL_ROOT = "/opt/nemo-rl"
+
+# ── Types ─────────────────────────────────────────────────────────────────────
+
+GPUType = Literal["H100", "H200", "B200", "B300", "A100"]
+
+class ModalConfig:
+    """Modal infrastructure configuration — GPU provisioning and image setup only."""
+
+    # Official NeMo-RL release image (https://registry.ngc.nvidia.com/orgs/nvidia/containers/nemo-rl).
+    docker_image: str = "nvcr.io/nvidia/nemo-rl:v0.5.0"
+    gpu: GPUType = "H100"
+    memory: tuple[int, int] | None = (
+        None  # per-container memory in MiB; see https://modal.com/docs/guide/resources#memory-limits
+    )
+    cloud: str | None = None  # e.g. "aws", "gcp"
+    region: str | None = None  # e.g. "us-east-2"
+    local_nemo_rl: str | None = None  # path to local NeMo-RL repo for dev overlay
+    image_run_commands: list[str] = []  # extra commands to run during image build
+    image_env: dict[str, str] = {}  # env vars baked into the image (Modal .env())
+
+    def __init__(self, **kwargs: Any) -> None:
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+def _hydra_value(val: Any) -> str:
+    """Serialize a Python value into a Hydra override RHS string."""
+    if val is None:
+        return "null"
+    if isinstance(val, bool):
+        return "true" if val else "false"
+    if isinstance(val, (list, tuple)):
+        return "[" + ",".join(_hydra_value(v) for v in val) + "]"
+    return str(val)
+
+
+class NemoRLConfig:
+    """Base NeMo-RL recipe configuration.
+
+    Subclass and set class attributes to configure an experiment. The launcher
+    runs::
+
+        uv run python <entrypoint> --config <base_config> <hydra overrides>
+
+    on the Ray head node, after the Modal cluster's Ray cluster is up.
+
+    Launcher fields:
+      entrypoint    — run script relative to /opt/nemo-rl (e.g. examples/run_grpo.py)
+      base_config   — YAML config path passed to --config
+      num_nodes     — total Modal/Ray nodes (also set as cluster.num_nodes)
+      gpus_per_node — GPUs per node (also set as cluster.gpus_per_node)
+      hf_model      — model id to prefetch into the HF cache; defaults to the
+                      policy.model_name override, else the base config's value
+      hf_datasets   — optional dataset repo ids to prefetch in download_data()
+      environment   — extra environment variables for the driver process
+
+    Recipe knobs:
+      overrides     — dict of dotted Hydra keys → values, applied on top of the
+                      base YAML config (e.g. {"policy.model_name": "Qwen/Qwen2.5-1.5B"})
+
+    Example::
+
+        class _Recipe(NemoRLConfig):
+            entrypoint = "examples/run_grpo.py"
+            base_config = "examples/configs/grpo_math_1B.yaml"
+            num_nodes = 1
+            gpus_per_node = 8
+            overrides = {
+                "policy.model_name": "Qwen/Qwen2.5-1.5B",
+                "logger.wandb_enabled": True,
+            }
+
+        nemo_rl = _Recipe()
+    """
+
+    # ── Launcher instructions ───────────────────────────────────────────────────
+    entrypoint: str = "examples/run_grpo.py"
+    base_config: str = "examples/configs/grpo_math_1B.yaml"
+    num_nodes: int = 1
+    gpus_per_node: int = 8
+    hf_model: str | None = None
+    hf_datasets: list[str] = []
+    environment: dict[str, str] = {}
+
+    # ── Recipe knobs ────────────────────────────────────────────────────────────
+    overrides: dict[str, Any] = {}
+
+    def __init__(self, **kwargs: Any) -> None:
+        # Fresh mutable copies per instance — never mutate the class-level defaults.
+        self.overrides = dict(type(self).overrides)
+        self.environment = dict(type(self).environment)
+        self.hf_datasets = list(type(self).hf_datasets)
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+    # ── Public API ──────────────────────────────────────────────────────────────
+
+    def total_nodes(self) -> int:
+        """Total Modal cluster nodes required by this recipe."""
+        return self.num_nodes
+
+    def resolved_overrides(self, experiment: str | None = None) -> dict[str, Any]:
+        """Hydra overrides with launcher-managed defaults merged in.
+
+        The cluster shape and checkpoint directory are forced to match the Modal
+        cluster and mounted checkpoints volume. Explicit ``overrides`` win over
+        the default checkpoint dir, never over cluster shape. ``experiment`` (the
+        config file stem) keys the default checkpoint dir so recipes don't
+        collide on the shared volume.
+        """
+        run_name = experiment or type(self).__name__
+        merged: dict[str, Any] = {
+            "checkpointing.checkpoint_dir": f"{CHECKPOINTS_PATH}/{run_name}",
+        }
+        merged.update(self.overrides)
+        # Cluster shape always tracks the actual Modal allocation.
+        merged["cluster.num_nodes"] = self.num_nodes
+        merged["cluster.gpus_per_node"] = self.gpus_per_node
+        return merged
+
+    def cli_args(self, experiment: str | None = None) -> list[str]:
+        """Argument list for the NeMo-RL run script.
+
+        Produces ``["--config", <base_config>, "k=v", ...]`` with Hydra-encoded
+        values (True→true, None→null, lists→[a,b]).
+        """
+        out = ["--config", self.base_config]
+        for key, val in self.resolved_overrides(experiment).items():
+            out.append(f"{key}={_hydra_value(val)}")
+        return out
+
+    def model_id(self) -> str | None:
+        """Hugging Face model id this recipe trains, for prefetching."""
+        return self.hf_model or self.overrides.get("policy.model_name")

--- a/nemo-rl/configs/llama3_1_8b_math_2node.py
+++ b/nemo-rl/configs/llama3_1_8b_math_2node.py
@@ -1,0 +1,36 @@
+"""Llama-3.1-8B-Instruct GRPO on OpenMathInstruct-2 — 2 nodes x 8 GPUs.
+
+Mirrors NeMo-RL's examples/configs/grpo_math_8B.yaml scaled to two nodes. This
+is the multi-node example: Modal provisions a 2-node RDMA cluster, the launcher
+brings up Ray across both nodes, and the driver runs on the head node with
+cluster.num_nodes=2.
+"""
+
+from configs.base import ModalConfig, NemoRLConfig
+
+modal = ModalConfig(gpu="H100")
+
+
+class _Recipe(NemoRLConfig):
+    entrypoint = "examples/run_grpo.py"
+    base_config = "examples/configs/grpo_math_8B.yaml"
+
+    num_nodes = 2
+    gpus_per_node = 8
+
+    hf_model = "meta-llama/Llama-3.1-8B-Instruct"
+    hf_datasets = ["nvidia/OpenMathInstruct-2"]
+
+    overrides = {
+        "policy.model_name": "meta-llama/Llama-3.1-8B-Instruct",
+        "policy.dtensor_cfg.enabled": True,
+        "policy.dtensor_cfg.tensor_parallel_size": 8,
+        "policy.dtensor_cfg.sequence_parallel": True,
+        "policy.dtensor_cfg.activation_checkpointing": True,
+        "logger.wandb_enabled": True,
+        "logger.wandb.project": "nemo-rl-grpo",
+        "logger.wandb.name": "llama3.1-8b-math-2node",
+    }
+
+
+nemo_rl = _Recipe()

--- a/nemo-rl/configs/nemotron_nano_v3_30ba3b_math_2node.py
+++ b/nemo-rl/configs/nemotron_nano_v3_30ba3b_math_2node.py
@@ -1,0 +1,39 @@
+"""Nemotron-3-Nano-30B-A3B (MoE) GRPO on OpenMathInstruct-2 — 2 nodes x 8 GPUs.
+
+Uses NeMo-RL's convergence-tested 2-node recipe
+``examples/configs/recipes/llm/grpo-nanov3-30BA3B-2n8g-fsdp2.yaml`` verbatim as
+the base config: FSDP2 with expert_parallel_size=8 for the 30B/3B-active MoE,
+nemo-automodel TransformerEngine backend + DeepEP, and vLLM tensor_parallel_size=4
+for generation. Modal provisions a 2-node RDMA cluster (16xH100) and the driver
+runs on the head node.
+
+This recipe is only shipped in NeMo-RL >= v0.6.0, so this config pins the
+matching v0.6.0 image rather than the repo default (v0.5.0).
+"""
+
+from configs.base import ModalConfig, NemoRLConfig
+
+modal = ModalConfig(gpu="H100", docker_image="nvcr.io/nvidia/nemo-rl:v0.6.0")
+
+
+class _Recipe(NemoRLConfig):
+    entrypoint = "examples/run_grpo.py"
+    base_config = "examples/configs/recipes/llm/grpo-nanov3-30BA3B-2n8g-fsdp2.yaml"
+
+    num_nodes = 2
+    gpus_per_node = 8
+
+    # Model and tokenizer live in separate HF repos; only the model is prefetched
+    # here, the tokenizer is fetched on first use.
+    hf_model = "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-Base-BF16"
+    hf_datasets = ["nvidia/OpenMathInstruct-2"]
+
+    # The recipe already sets every MoE/parallelism knob; only override logging.
+    overrides = {
+        "logger.wandb_enabled": True,
+        "logger.wandb.project": "nemo-rl-grpo",
+        "logger.wandb.name": "nemotron-nano-v3-30ba3b-math-2node",
+    }
+
+
+nemo_rl = _Recipe()

--- a/nemo-rl/configs/qwen2_5_1_5b_math.py
+++ b/nemo-rl/configs/qwen2_5_1_5b_math.py
@@ -1,0 +1,33 @@
+"""Qwen2.5-1.5B GRPO on OpenMathInstruct-2 — single node, 8 GPUs.
+
+Mirrors NeMo-RL's examples/configs/grpo_math_1B.yaml, bumped to a full 8-GPU
+node. The dataset is downloaded automatically by NeMo-RL at runtime into the
+mounted HF cache, so download_data is only used to warm that cache.
+"""
+
+from configs.base import ModalConfig, NemoRLConfig
+
+modal = ModalConfig(gpu="H100")
+
+
+class _Recipe(NemoRLConfig):
+    entrypoint = "examples/run_grpo.py"
+    base_config = "examples/configs/grpo_math_1B.yaml"
+
+    num_nodes = 1
+    gpus_per_node = 8
+
+    hf_model = "Qwen/Qwen2.5-1.5B"
+    hf_datasets = ["nvidia/OpenMathInstruct-2"]
+
+    overrides = {
+        "policy.model_name": "Qwen/Qwen2.5-1.5B",
+        # Spread generation + training across all 8 GPUs.
+        "policy.generation.vllm_cfg.tensor_parallel_size": 1,
+        "logger.wandb_enabled": True,
+        "logger.wandb.project": "nemo-rl-grpo",
+        "logger.wandb.name": "qwen2.5-1.5b-math",
+    }
+
+
+nemo_rl = _Recipe()

--- a/nemo-rl/configs/qwen2_5_1_5b_math_2node.py
+++ b/nemo-rl/configs/qwen2_5_1_5b_math_2node.py
@@ -1,0 +1,35 @@
+"""Qwen2.5-1.5B GRPO on OpenMathInstruct-2 — 2 nodes x 8 GPUs.
+
+Same recipe as qwen2_5_1_5b_math (grpo_math_1B.yaml), scaled to two nodes.
+Modal provisions a 2-node RDMA cluster and NeMo-RL schedules across all 16 GPUs.
+"""
+
+from configs.base import ModalConfig, NemoRLConfig
+
+modal = ModalConfig(gpu="H100")
+
+
+class _Recipe(NemoRLConfig):
+    entrypoint = "examples/run_grpo.py"
+    base_config = "examples/configs/grpo_math_1B.yaml"
+
+    num_nodes = 2
+    gpus_per_node = 8
+
+    hf_model = "Qwen/Qwen2.5-1.5B"
+    hf_datasets = ["nvidia/OpenMathInstruct-2"]
+
+    overrides = {
+        "policy.model_name": "Qwen/Qwen2.5-1.5B",
+        # Base config ties max_input_seq_length, max_model_len, and max_new_tokens
+        # all to max_total_sequence_length (512). A 512-token prompt then leaves no
+        # room for generation and vLLM raises. Bump it so prompt + output fit.
+        "policy.max_total_sequence_length": 1024,
+        "policy.generation.vllm_cfg.tensor_parallel_size": 1,
+        "logger.wandb_enabled": True,
+        "logger.wandb.project": "nemo-rl-grpo",
+        "logger.wandb.name": "qwen2.5-1.5b-math-2node",
+    }
+
+
+nemo_rl = _Recipe()

--- a/nemo-rl/configs/qwen3_8b_math.py
+++ b/nemo-rl/configs/qwen3_8b_math.py
@@ -1,0 +1,33 @@
+"""Qwen2.5-1.5B GRPO on OpenMathInstruct-2 — single node, 8 GPUs.
+
+Mirrors NeMo-RL's examples/configs/grpo_math_1B.yaml, bumped to a full 8-GPU
+node. The dataset is downloaded automatically by NeMo-RL at runtime into the
+mounted HF cache, so download_data is only used to warm that cache.
+"""
+
+from configs.base import ModalConfig, NemoRLConfig
+
+modal = ModalConfig(gpu="H100")
+
+
+class _Recipe(NemoRLConfig):
+    entrypoint = "examples/run_grpo.py"
+    base_config = "examples/configs/grpo_math_1B.yaml"
+
+    num_nodes = 1
+    gpus_per_node = 8
+
+    hf_model = "Qwen/Qwen3-8B"
+    hf_datasets = ["nvidia/OpenMathInstruct-2"]
+
+    overrides = {
+        "policy.model_name": "Qwen/Qwen3-8B",
+        # Spread generation + training across all 8 GPUs.
+        "policy.generation.vllm_cfg.tensor_parallel_size": 1,
+        "logger.wandb_enabled": True,
+        "logger.wandb.project": "nemo-rl-grpo",
+        "logger.wandb.name": "qwen3-8b-math",
+    }
+
+
+nemo_rl = _Recipe()

--- a/nemo-rl/modal_helpers/run_grpo_multinode.py
+++ b/nemo-rl/modal_helpers/run_grpo_multinode.py
@@ -1,0 +1,113 @@
+"""
+Helpers to run NemoRL multinode jobs on Modal.
+
+There are two problems that break colocated training across Modal nodes in NemoRL:
+
+- Placement: Colocated VLLM has fractional Ray GPUs (0.5 per actor) so all 16 workers
+  could fit in one node's placement group, which leaves the other node empty (in NemoRL, SLURM scheduler ensures each pg goes to a separate node). We force a
+  single placement group of 16 whole-GPU bundles and spread them across nodes with Ray's
+  SPREAD, whereas the default NemoRL recipe will create one placement group per node. This way gpus_per_node bundles are put into one node, which ensures one rank per GPU.
+
+- Once placement is right, Modal gives every container the same NCCL_HOSTID and same hostname, and NemoRL will copy the driver's env onto every worker. 
+Because of this, when NCCL keys on (hostHash, busId) it will find two gpus on the same rank on different nodes (ie. gpu 2 on nodes 0 and 1) are the same device and give a duplicate GPU error. 
+
+To fix this we manually set each worker's NCCL_HOSTID from the physical Ray node its bundle landed on, so ranks on different nodes look distinct.
+"""
+
+from __future__ import annotations
+
+import os
+import runpy
+
+# Force bundles to spread across nodes. NemoRL defaults to one placement group per node
+# (relying on SLURM to keep them apart); on Modal we use a single unified placement group
+# so Ray's SPREAD strategy balances whole-GPU bundles across nodes instead of packing them
+# onto one.
+def _patch_virtual_cluster() -> None:
+    from nemo_rl.distributed.virtual_cluster import RayVirtualCluster
+
+    if getattr(RayVirtualCluster, "_modal_multinode_patched", False):
+        return
+
+    _orig_init_pg = RayVirtualCluster._init_placement_groups
+
+    def _init_placement_groups(self, strategy=None, use_unified_pg=False):
+        if len(self._bundle_ct_per_node_list) > 1 and self.use_gpus:
+            use_unified_pg = True
+        return _orig_init_pg(self, strategy=strategy, use_unified_pg=use_unified_pg)
+
+    RayVirtualCluster._init_placement_groups = _init_placement_groups
+    RayVirtualCluster._modal_multinode_patched = True
+
+
+def _bundle_node_id(placement_group, bundle_index: int) -> str | None:
+    """Physical Ray node id hosting a given bundle of a placement group.
+
+    The node id is unique per machine, so it's the right seed for a per-node NCCL
+    host hash. Best-effort: returns None if the placement table isn't populated.
+    """
+    from ray.util.placement_group import placement_group_table
+
+    try:
+        table = placement_group_table(placement_group)
+        return table.get("bundles_to_node_id", {}).get(bundle_index)
+    except Exception:
+        return None
+
+
+# Modal gives every container the same NCCL_HOSTID, so NCCL keys on (hostHash, busId)
+# and treats same-busId GPUs on different nodes as one device ("Duplicate GPU detected").
+# We override NCCL_HOSTID per physical node.
+def _patch_worker_group_hostid() -> None:
+    """Give each worker an NCCL_HOSTID keyed to its physical node."""
+    from nemo_rl.distributed import worker_groups as wg
+
+    if getattr(wg.RayWorkerBuilder, "_modal_hostid_patched", False):
+        return
+
+    _orig_create_worker_async = wg.RayWorkerBuilder.create_worker_async
+
+    def create_worker_async(
+        self,
+        placement_group,
+        placement_group_bundle_index,
+        num_gpus,
+        bundle_indices=None,
+        **extra_options,
+    ):
+        node_id = _bundle_node_id(placement_group, placement_group_bundle_index)
+        if node_id is not None:
+            env_vars = extra_options.setdefault("runtime_env", {}).setdefault(
+                "env_vars", {}
+            )
+            env_vars["NCCL_HOSTID"] = f"modal-node-{node_id}"
+            print(
+                f"[modal] bundle={placement_group_bundle_index} "
+                f"NCCL_HOSTID=modal-node-{node_id}",
+                flush=True,
+            )
+        return _orig_create_worker_async(
+            self,
+            placement_group,
+            placement_group_bundle_index,
+            num_gpus,
+            bundle_indices,
+            **extra_options,
+        )
+
+    wg.RayWorkerBuilder.create_worker_async = create_worker_async
+    wg.RayWorkerBuilder._modal_hostid_patched = True
+
+
+def main() -> None:
+    # Surface NCCL's per-rank hostHash/busId so duplicate-GPU errors are diagnosable.
+    # This is set in the driver env, which NeMo-RL copies onto every worker.
+    os.environ.setdefault("NCCL_DEBUG", "INFO")
+    os.environ.setdefault("NCCL_DEBUG_SUBSYS", "INIT,ENV")
+    _patch_virtual_cluster()
+    _patch_worker_group_hostid()
+    runpy.run_path("examples/run_grpo.py", run_name="__main__")
+
+
+if __name__ == "__main__":
+    main()

--- a/nemo-rl/modal_helpers/utils.py
+++ b/nemo-rl/modal_helpers/utils.py
@@ -1,0 +1,191 @@
+"""
+General helpers for Ray multinode 
+"""
+import json
+import shlex
+import subprocess
+import time
+
+# Glob covering both lib/ and lib64/ python site-packages in the NeMo-RL venv.
+_NSIGHT_GLOB = (
+    "/opt/nemo_rl_venv/lib*/python*/site-packages/ray/_private/runtime_env/nsight.py"
+)
+
+# Keep Ray worker ports below the OS ephemeral range (see NeMo-RL ray.sub).
+_MIN_WORKER_PORT = 10002
+_MAX_WORKER_PORT = 11000
+
+
+def _ray_node_resources(gpus_per_node: int, node_rank: int | None = None) -> str:
+    """Custom Ray resources registered by NeMo-RL's ray.sub on every node."""
+    resources: dict[str, int] = {
+        "worker_units": gpus_per_node,
+        "slurm_managed_ray_cluster": 1,
+    }
+    if node_rank is not None:
+        resources[f"modal_node_{node_rank}"] = 1
+    return json.dumps(resources, separators=(",", ":"))
+
+
+def cluster_driver_env(head_ip: str, cluster_ips: list[str] | None = None) -> dict[str, str]:
+    """Environment for the NeMo-RL driver and Ray actors on a multi-node cluster."""
+    no_proxy_hosts = ",".join(dict.fromkeys(["127.0.0.1", head_ip, *(cluster_ips or [])]))
+    return {
+        # NeMo-RL uses `uv run` itself; disable Ray's per-task uv runtime env (ray.sub).
+        "RAY_ENABLE_UV_RUN_RUNTIME_ENV": "0",
+        "TRAIN_ENABLE_SHARE_CUDA_VISIBLE_DEVICES": "0",
+        "MASTER_ADDR": head_ip,
+        "no_proxy": no_proxy_hosts,
+        "NCCL_NVLS_ENABLE": "0",
+        "CUDA_DEVICE_MAX_CONNECTIONS": "1",
+    }
+
+
+def get_modal_cluster_context(n_nodes: int) -> tuple[int, str, str, int, list[str]]:
+    """Return (rank, head_ip, my_ip, n_nodes, cluster_ips) for the current Modal cluster."""
+    if n_nodes == 1:
+        return 0, "127.0.0.1", "127.0.0.1", 1, ["127.0.0.1"]
+
+    import modal.experimental
+
+    info = modal.experimental.get_cluster_info()
+    actual_nodes = len(info.container_ipv4_ips)
+    if actual_nodes != n_nodes:
+        raise RuntimeError(
+            f"cluster size mismatch: expected {n_nodes} node(s), got {actual_nodes}"
+        )
+    return (
+        info.rank,
+        info.container_ipv4_ips[0],
+        info.container_ipv4_ips[info.rank],
+        actual_nodes,
+        list(info.container_ipv4_ips),
+    )
+
+# TODO: probably unnecessary and can be removed
+def _patch_nsight() -> None:
+    """Mirror ray.sub's nsight patch so Ray honors NeMo-RL's py_executable.
+
+    NeMo-RL launches workers via ``uv run``; Ray's nsight runtime-env plugin
+    otherwise hardcodes ``python`` and breaks profiling. Best-effort.
+    """
+    import glob
+
+    sed = (
+        r's/context\.py_executable = " "\.join(self\.nsight_cmd) + " python"/'
+        r'context.py_executable = " ".join(self.nsight_cmd) + f" {context.py_executable}"/g'
+    )
+    for path in glob.glob(_NSIGHT_GLOB):
+        subprocess.run(["sed", "-i", sed, path], check=False)
+
+
+def _wait_for_ray_cluster(
+    ray, n_nodes: int, gpus_per_node: int, timeout_s: int = 240
+) -> None:
+    """Block until each Ray node has registered its GPUs (not just cluster-wide total)."""
+    expected_gpus = n_nodes * gpus_per_node
+    for _ in range(timeout_s // 2):
+        alive = [n for n in ray.nodes() if n["Alive"]]
+        total_gpus = int(ray.cluster_resources().get("GPU", 0))
+        per_node = sorted(
+            (
+                n.get("NodeManagerAddress"),
+                int(n.get("Resources", {}).get("GPU", 0)),
+            )
+            for n in alive
+        )
+        ready_nodes = sum(1 for _, g in per_node if g >= gpus_per_node)
+        print(
+            f"Waiting for cluster: {len(alive)}/{n_nodes} nodes, "
+            f"{total_gpus}/{expected_gpus} GPUs, "
+            f"{ready_nodes}/{n_nodes} nodes with >={gpus_per_node} GPU(s)"
+        )
+        print(f"  per-node: {per_node}")
+        if (
+            len(alive) >= n_nodes
+            and total_gpus >= expected_gpus
+            and ready_nodes >= n_nodes
+        ):
+            return
+        time.sleep(2)
+    raise RuntimeError(
+        f"Timed out waiting for {n_nodes} nodes each with {gpus_per_node} GPUs "
+        f"(cluster total {expected_gpus})"
+    )
+
+# Nemo-RL launches training through a SLURM bash script (https://github.com/NVIDIA-NeMo/RL/blob/main/ray.sub) getting nodes from a list SLURM_JOBS_NODELIST
+# instead we break this up into start_ray_head and start_ray_worker
+def start_ray_head(
+    head_ip: str, port: int, n_nodes: int, gpus_per_node: int, node_rank: int = 0
+) -> None:
+    """Start the Ray head and block until every node and GPU has joined."""
+    import ray
+
+    _patch_nsight()
+    subprocess.Popen(
+        [
+            "ray",
+            "start",
+            "--head",
+            "--disable-usage-stats",
+            f"--num-gpus={gpus_per_node}",
+            f"--resources={_ray_node_resources(gpus_per_node, node_rank)}",
+            f"--node-ip-address={head_ip}",
+            f"--port={port}",
+            "--dashboard-host=0.0.0.0",
+            "--include-dashboard=True",
+            "--block",
+        ]
+    )
+
+    for _ in range(60):
+        try:
+            ray.init(address="auto")
+            break
+        except Exception:
+            time.sleep(2)
+    else:
+        raise RuntimeError("Ray head node failed to start")
+
+    _wait_for_ray_cluster(ray, n_nodes, gpus_per_node)
+    # Detach the driver-side ray handle; the NeMo-RL driver reconnects itself.
+    ray.shutdown()
+
+
+def start_ray_worker(
+    head_ip: str, port: int, my_ip: str, gpus_per_node: int, node_rank: int
+) -> None:
+    """Start a Ray worker that joins the head and blocks forever."""
+    _patch_nsight()
+    subprocess.Popen(
+        [
+            "ray",
+            "start",
+            f"--node-ip-address={my_ip}",
+            "--address",
+            f"{head_ip}:{port}",
+            "--disable-usage-stats",
+            f"--num-gpus={gpus_per_node}",
+            f"--resources={_ray_node_resources(gpus_per_node, node_rank)}",
+            f"--min-worker-port={_MIN_WORKER_PORT}",
+            f"--max-worker-port={_MAX_WORKER_PORT}",
+            "--block",
+        ]
+    )
+
+
+
+def build_train_cmd(nemo_rl_cfg, nemo_rl_root: str, experiment: str | None = None) -> str:
+    """Build the driver command run on the Ray head node."""
+    import importlib.util
+
+    args = shlex.join(nemo_rl_cfg.cli_args(experiment))
+    if nemo_rl_cfg.num_nodes > 1:
+        
+        spec = importlib.util.find_spec("modal_helpers.run_grpo_multinode")
+        if spec is None or spec.origin is None:
+            raise RuntimeError("modal_helpers.run_grpo_multinode not found in image")
+        entrypoint = spec.origin
+    else:
+        entrypoint = nemo_rl_cfg.entrypoint
+    return f"cd {shlex.quote(nemo_rl_root)} && uv run python {shlex.quote(entrypoint)} {args}"

--- a/nemo-rl/modal_train.py
+++ b/nemo-rl/modal_train.py
@@ -1,0 +1,204 @@
+import asyncio
+import os
+import subprocess
+
+import modal
+import modal.experimental
+
+from configs import get_module, _CONFIGS_DIR
+from configs.base import (
+    CHECKPOINTS_PATH,
+    HF_CACHE_PATH,
+    NEMO_RL_ROOT,
+    ModalConfig,
+)
+
+# ── Experiment (client-side only — feeds decorator params) ────────────────────
+
+experiment = os.environ.get("EXPERIMENT_CONFIG", "")
+exp_mod = get_module(experiment) if experiment else None
+modal_cfg = exp_mod.modal if exp_mod else None
+nemo_rl_cfg = exp_mod.nemo_rl if exp_mod else None
+
+# ── Image ─────────────────────────────────────────────────────────────────────
+
+image = (
+    modal.Image.from_registry(
+        modal_cfg.docker_image if modal_cfg else ModalConfig.docker_image
+    )
+    .entrypoint([])
+    .add_local_python_source("configs", copy=True)
+    .add_local_python_source("modal_helpers", copy=True)
+)
+if modal_cfg:
+    if modal_cfg.local_nemo_rl:
+        image = image.add_local_dir(
+            modal_cfg.local_nemo_rl,
+            remote_path=NEMO_RL_ROOT,
+            copy=True,
+            ignore=[
+                "**/__pycache__",
+                "**/*.pyc",
+                "**/.git",
+                "**/.venv",
+                "**/results",
+                "**/logs",
+            ],
+        )
+    if modal_cfg.image_run_commands:
+        image = image.run_commands(*modal_cfg.image_run_commands)
+    if modal_cfg.image_env:
+        image = image.env(modal_cfg.image_env)
+
+with image.imports():
+    from modal_helpers.utils import (
+        build_train_cmd,
+        cluster_driver_env,
+        get_modal_cluster_context,
+        start_ray_head,
+        start_ray_worker,
+    )
+
+# ── Volumes ───────────────────────────────────────────────────────────────────
+
+hf_cache_volume = modal.Volume.from_name("huggingface-cache", create_if_missing=True)
+checkpoints_volume = modal.Volume.from_name(
+    "nemo-rl-checkpoints", create_if_missing=True
+)
+
+modal_volumes = {
+    str(HF_CACHE_PATH): hf_cache_volume,
+    str(CHECKPOINTS_PATH): checkpoints_volume,
+}
+
+# ── App ──────────────────────────────────────────────────────────────────────
+
+app = modal.App(experiment)
+
+RAY_PORT = 6379
+RAY_DASHBOARD_PORT = 8265
+
+
+@app.local_entrypoint()
+def list_configs():
+    """Print all available experiments."""
+    _skip = {"base", "__init__"}
+    names = sorted(f.stem for f in _CONFIGS_DIR.glob("*.py") if f.stem not in _skip)
+    print("Available experiments:")
+    for name in names:
+        mod = get_module(name)
+        cfg = mod.nemo_rl
+        gpu = f"{mod.modal.gpu}:{cfg.gpus_per_node}"
+        print(
+            f"  {name:<40} {cfg.num_nodes} node(s) × {gpu}  "
+            f"({os.path.basename(cfg.entrypoint)})"
+        )
+
+
+@app.function(
+    image=image,
+    volumes={str(HF_CACHE_PATH): hf_cache_volume},
+    timeout=4 * 60 * 60,
+    secrets=[modal.Secret.from_name("huggingface-secret")],
+)
+def download_model(experiment: str = os.environ.get("EXPERIMENT_CONFIG", "")):
+    """Prefetch the recipe's model into the mounted HF cache."""
+    from huggingface_hub import snapshot_download
+
+    cfg = get_module(experiment).nemo_rl
+    model_id = cfg.model_id()
+    if not model_id:
+        raise ValueError(
+            f"{experiment!r}: set hf_model or overrides['policy.model_name'] to download a model"
+        )
+    hf_cache_volume.reload()
+    print(f"Downloading model {model_id!r} into the HF cache...")
+    snapshot_download(model_id)
+    hf_cache_volume.commit()
+
+
+@app.function(
+    image=image,
+    volumes={str(HF_CACHE_PATH): hf_cache_volume},
+    timeout=4 * 60 * 60,
+    secrets=[modal.Secret.from_name("huggingface-secret")],
+)
+def download_data(experiment: str = os.environ.get("EXPERIMENT_CONFIG", "")):
+    # fetch dataset from huggingface (optional, nemorl will do this automatically)
+    cfg = get_module(experiment).nemo_rl
+    if not cfg.hf_datasets:
+        print(f"{experiment!r} declares no hf_datasets; nothing to prefetch.")
+        return
+
+    from datasets import load_dataset
+
+    hf_cache_volume.reload()
+    for repo_id in cfg.hf_datasets:
+        print(f"Prefetching dataset {repo_id!r}...")
+        load_dataset(repo_id)
+    hf_cache_volume.commit()
+
+
+
+@app.function(
+    image=image,
+    gpu=f"{modal_cfg.gpu}:{nemo_rl_cfg.gpus_per_node}" if modal_cfg else None,
+    memory=modal_cfg.memory if modal_cfg and modal_cfg.memory else None,
+    cloud=modal_cfg.cloud if modal_cfg and modal_cfg.cloud else None,
+    region=modal_cfg.region if modal_cfg and modal_cfg.region else None,
+    volumes=modal_volumes,
+    secrets=[
+        modal.Secret.from_name("huggingface-secret"),
+        modal.Secret.from_name("wandb-secret"),
+    ],
+    timeout=24 * 60 * 60,
+    experimental_options={"efa_enabled": True},
+)
+@(
+    modal.experimental.clustered(nemo_rl_cfg.total_nodes(), rdma=True)
+    if nemo_rl_cfg
+    else lambda fn: fn
+)
+async def train(experiment: str = os.environ.get("EXPERIMENT_CONFIG", "")):
+    await asyncio.gather(
+        hf_cache_volume.reload.aio(),
+        checkpoints_volume.reload.aio(),
+    )
+    exp_mod = get_module(experiment)
+    cfg = exp_mod.nemo_rl
+    modal_cfg = exp_mod.modal
+
+    rank, head_ip, my_ip, n_nodes, cluster_ips = get_modal_cluster_context(
+        cfg.total_nodes()
+    )
+
+    # on all ranks that are not the head node, do ray --start and spin
+    if rank != 0:
+        
+        start_ray_worker(head_ip, RAY_PORT, my_ip, cfg.gpus_per_node, rank)
+        while True:
+            await asyncio.sleep(10)
+
+    # on the head node, start ray and wait for all nodes to join 
+    start_ray_head(head_ip, RAY_PORT, n_nodes, cfg.gpus_per_node, node_rank=rank)
+    
+
+    cmd = build_train_cmd(cfg, NEMO_RL_ROOT, experiment)
+    env = {
+        **os.environ,
+        "RAY_ADDRESS": f"{head_ip}:{RAY_PORT}",
+        **cluster_driver_env(head_ip, cluster_ips),
+        **cfg.environment,
+    }
+
+    gpu = f"{modal_cfg.gpu}:{cfg.gpus_per_node}"
+    print(f"Training {experiment:<40} {n_nodes} node(s) × {gpu}")
+    print(f"Command: {cmd}")
+
+    async with modal.forward(RAY_DASHBOARD_PORT) as tunnel:
+        print(f"Ray dashboard: {tunnel.url}")
+        result = subprocess.run(["bash", "-c", cmd], env=env)
+
+    await checkpoints_volume.commit.aio()
+    if result.returncode != 0:
+        raise RuntimeError(f"NeMo-RL driver exited with code {result.returncode}")


### PR DESCRIPTION
This adds a self-contained launcher for running multinode training using NemoRL on Modal, covering both single-node and multi-node (RDMA/EFA) clusters.

The organization is taken from the Slime example, with a small config system (`configs/base.py`) where each experiment is a Python module exposing a modal object and nemo_rl object (which run script to use, which base YAML from NemoRL, and a dict of overrides). Similar to the Slime example, `modal_train.py` turns that into a Modal app with `download_model`, `download_data`, and `train` entry points, starting a Ray cluster  across the allocated nodes and running the NemoRL driver on the head node w/ the HF cache and checkpoints mounted as volumes. 

Tested examples: GRPO on OpenMathInstruct-2 math task: Qwen2.5-1.5B (single and 2-node DP), Llama-3.1-8B two-node, Qwen3-8B, and a Nemotron-Nano-v3-30B-A3B MoE FSDP + EP two-node config. README contains setup + launch instructions 


<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-labs/multinode-training-guide/pull/89" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->