### PR TITLE
[codex] Support GLM-5.2 744B Modal H100 run

### DIFF
--- a/health-checks/modal_net_diag.py
+++ b/health-checks/modal_net_diag.py
@@ -1,0 +1,85 @@
+import os
+import subprocess
+
+import modal
+import modal.experimental
+
+
+image = modal.Image.from_registry(
+    "slimerl/slime:nightly-dev-20260629a"
+).entrypoint([]).apt_install("iproute2")
+app = modal.App("modal-net-diag-glm52", image=image)
+
+
+def run(cmd: str) -> None:
+    print(f"$ {cmd}", flush=True)
+    proc = subprocess.run(
+        ["bash", "-lc", cmd],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    print(proc.stdout, end="", flush=True)
+    print(f"[exit {proc.returncode}]", flush=True)
+
+
+@app.function(
+    gpu="H100:8",
+    cloud="aws",
+    timeout=15 * 60,
+    experimental_options={"efa_enabled": True},
+)
+@modal.experimental.clustered(2, rdma=True)
+def diag():
+    info = modal.experimental.get_cluster_info()
+    print(f"rank={info.rank}", flush=True)
+    print(f"container_ipv4_ips={info.container_ipv4_ips}", flush=True)
+    print(f"container_ips={getattr(info, 'container_ips', None)}", flush=True)
+    print(f"task_id={os.environ.get('MODAL_TASK_ID')}", flush=True)
+
+    run("hostname -I || true")
+    run("ip -o -4 addr show || true")
+    run("ip route || true")
+    for ip in info.container_ipv4_ips:
+        run(f"ip route get {ip} || true")
+    run(
+        "for n in /sys/class/net/*; do "
+        "i=$(basename $n); "
+        "printf '%s mtu=' $i; cat $n/mtu 2>/dev/null; "
+        "printf '%s oper=' $i; cat $n/operstate 2>/dev/null; "
+        "done"
+    )
+    run("command -v ucx_info && ucx_info -d | sed -n '1,220p' || true")
+    run(
+        "UCX_TLS=tcp,cuda_copy,cuda_ipc UCX_NET_DEVICES=all "
+        "ucx_info -d 2>&1 | sed -n '1,220p' || true"
+    )
+    run(
+        "UCX_TLS=tcp,cuda_copy,cuda_ipc UCX_NET_DEVICES=eth0 "
+        "ucx_info -d 2>&1 | sed -n '1,160p' || true"
+    )
+    run(
+        "UCX_TLS=tcp,cuda_copy,cuda_ipc UCX_NET_DEVICES=overlay0 "
+        "ucx_info -d 2>&1 | sed -n '1,160p' || true"
+    )
+    run("/opt/amazon/efa/bin/fi_info -p tcp 2>/dev/null | head -80 || true")
+    run("/opt/amazon/efa/bin/fi_info -p sockets 2>/dev/null | head -80 || true")
+    run("FI_PROVIDER=efa /opt/amazon/efa/bin/fi_info -p efa 2>/dev/null | head -80 || true")
+    run(
+        "python3 - <<'PY'\n"
+        "import importlib\n"
+        "for name in ('nixl_cu12._api', 'nixl._api'):\n"
+        "    try:\n"
+        "        mod = importlib.import_module(name)\n"
+        "    except Exception as exc:\n"
+        "        print(name, 'IMPORT_ERROR', repr(exc))\n"
+        "        continue\n"
+        "    print(name, 'OK')\n"
+        "    print([x for x in dir(mod) if 'Agent' in x or 'agent' in x or 'backend' in x.lower()][:80])\n"
+        "PY"
+    )
+
+
+@app.local_entrypoint()
+def main():
+    diag.remote()

--- a/slime/configs/base.py
+++ b/slime/configs/base.py
@@ -34,6 +34,9 @@ _SLIME_SKIP = {
     "slime_model_script",
     "source_hf_checkpoint",
     "megatron_conversion_hf_checkpoint",
+    "conversion_tensor_model_parallel_size",
+    "conversion_pipeline_model_parallel_size",
+    "wandb_key",
 }
 
 # SlimeConfig fields that SLIME reads as YAML files at runtime.
@@ -52,11 +55,13 @@ class ModalConfig:
 
     docker_image: str = "slimerl/slime:nightly-dev-20260529a"
     gpu: GPUType = "H100"
+    conversion_gpu: GPUType | None = None
     memory: tuple[int, int] | None = (
         None  # per-container memory in MiB; check https://modal.com/docs/guide/resources#memory-limits
     )
     cloud: str | None = None  # e.g. "aws", "gcp"
     region: str | None = None  # e.g. "us-east-2"
+    efa_enabled: bool = True  # AWS EFA-specific Modal experimental option
     local_slime: str | None = None  # path to local slime repo for dev overlay
     patch_files: list[
         str
@@ -93,6 +98,10 @@ class SlimeConfig:
       megatron_conversion_hf_checkpoint — optional HF-format repo/local path to
                                           convert in convert_hf_to_megatron_checkpoint();
                                           defaults to hf_checkpoint
+      conversion_tensor_model_parallel_size / conversion_pipeline_model_parallel_size
+                            — optional raw-conversion TP/PP override when the
+                              checkpoint should be converted with a different
+                              sharding layout than training.
 
     Example:
 
@@ -120,6 +129,8 @@ class SlimeConfig:
     slime_model_script: str = ""  # shell script path relative to /root/slime
     source_hf_checkpoint: str | None = None
     megatron_conversion_hf_checkpoint: str | None = None
+    conversion_tensor_model_parallel_size: int | None = None
+    conversion_pipeline_model_parallel_size: int | None = None
 
     def __init__(self, **kwargs: Any) -> None:
         # Fresh environment dict per instance — never mutate the class-level default.

--- a/slime/configs/glm52_744b_a40b.py
+++ b/slime/configs/glm52_744b_a40b.py
@@ -1,0 +1,213 @@
+"""GLM-5.2-744B-A40B GRPO on DAPO-Math-17k — 32-node H100 colocated run.
+
+Aligned to upstream run-glm5.2-744B-A40B.sh, adapted for Modal.
+The upstream script uses PD disaggregation with InfiniBand. In this environment
+the available PD transfer paths are not usable: Mooncake TCP fails CUDA-buffer
+copies, NIXL/LIBFABRIC needs unavailable EFA memory-registration privileges on
+AWS, and NIXL/UCX only exposes loopback to the plugin. Use standard colocated
+SGLang rollout engines instead of cross-node KV transfer, and leave cloud/EFA
+placement open so Modal can find a 32-node H100 allocation.
+"""
+
+from configs.base import (
+    CHECKPOINTS_PATH,
+    DATA_PATH,
+    HF_CACHE_PATH,
+    ModalConfig,
+    SlimeConfig,
+)
+
+modal = ModalConfig(
+    docker_image="slimerl/slime:nightly-dev-20260629a",
+    gpu="H100",
+    conversion_gpu="H200",
+    cloud=None,
+    efa_enabled=False,
+    image_run_commands=[
+        # Remove baked HF cache paths before Modal mounts the shared cache volume.
+        f"rm -rf {HF_CACHE_PATH}",
+        "test -f /root/slime/scripts/models/glm5.2-744B-A40B.sh",
+    ],
+    memory=(1024, int(2 * 1024 * 1024)),
+)
+
+
+class _Slime(SlimeConfig):
+    slime_model_script = "scripts/models/glm5.2-744B-A40B.sh"
+
+    environment = {
+        "PYTHONPATH": "/root/slime:/root/Megatron-LM/",
+        "CUDA_DEVICE_MAX_CONNECTIONS": "1",
+        "CUDA_MODULE_LOADING": "LAZY",
+        "PYTHONUNBUFFERED": "1",
+        "NCCL_DEBUG": "WARN",
+        "GLOO_SOCKET_IFNAME": "overlay0",
+        "TP_SOCKET_IFNAME": "overlay0",
+        "NCCL_SOCKET_IFNAME": "=overlay0",
+        "NCCL_SOCKET_FAMILY": "AF_INET",
+        "NCCL_OOB_NET_IFNAME": "overlay0",
+        "NCCL_NVLS_ENABLE": "0",
+        "NCCL_CUMEM_ENABLE": "0",
+        "NCCL_NET_GDR_LEVEL": "2",
+        "NCCL_IB_QPS_PER_CONNECTION": "2",
+        "NCCL_IB_TC": "160",
+        "NCCL_IB_TIMEOUT": "22",
+        "NCCL_PXN_DISABLE": "0",
+        "NCCL_MIN_CTAS": "4",
+        "NVTE_FWD_LAYERNORM_SM_MARGIN": "8",
+        "NVTE_BWD_LAYERNORM_SM_MARGIN": "8",
+        "INDEXER_ROPE_NEOX_STYLE": "0",
+        "MC_IB_PCI_RELAXED_ORDERING": "1",
+        "MLP_SKIP_SORT_RDMA": "true",
+        "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "64",
+        "SGLANG_JIT_DEEPGEMM_PRECOMPILE": "true",
+        "SGLANG_QUANT_ALLOW_DOWNCASTING": "1",
+        "NVSHMEM_DISABLE_NCCL": "1",
+        "NVSHMEM_BOOTSTRAP_UID_SOCK_IFNAME": "=overlay0",
+        "NVSHMEM_BOOTSTRAP_UID_SOCK_FAMILY": "AF_INET",
+        "NVSHMEM_REMOTE_TRANSPORT": "libfabric",
+        "NVSHMEM_LIBFABRIC_PROVIDER": "efa",
+        "NVSHMEM_LIBFABRIC_SUPPORT": "1",
+        "NVSHMEM_DISABLE_IB": "1",
+        "NVSHMEM_DISABLE_IBRC": "1",
+        "NVSHMEM_DISABLE_IBGDA": "1",
+        "NVSHMEM_DISABLE_P2P": "1",
+        "NVSHMEM_DISABLE_CUDA_VMM": "1",
+        "NVSHMEM_USE_GDRCOPY": "0",
+        "MODAL_DCP_BUFFERED_TORCH_SAVE": "1",
+        "MODAL_DCP_THREAD_COUNT": "1",
+        "PATCH_MEGATRON_ALLGATHER_CP_ROPE": "1",
+    }
+
+    # ── Model ─────────────────────────────────────────────────────────────────
+    hf_checkpoint = "zai-org/GLM-5.2-FP8"
+    load = hf_checkpoint
+    ref_load = None
+    save = None
+    save_interval = None
+    megatron_to_hf_mode = "bridge"
+
+    # ── Infrastructure ────────────────────────────────────────────────────────
+    actor_num_nodes = 32
+    actor_num_gpus_per_node = 8
+    colocate = True
+    no_check_for_nan_in_loss_and_grad = True
+    update_weight_buffer_size = 512 * 1024**2
+
+    # ── Data ──────────────────────────────────────────────────────────────────
+    prompt_data = f"{DATA_PATH}/dapo-math-17k/dapo-math-17k.jsonl"
+    input_key = "prompt"
+    label_key = "label"
+    apply_chat_template = True
+    rollout_shuffle = True
+    rm_type = "deepscaler"
+
+    # ── Rollout ───────────────────────────────────────────────────────────────
+    num_rollout = 3000
+    rollout_batch_size = 8
+    n_samples_per_prompt = 8
+    rollout_max_response_len = 1024
+    rollout_temperature = 1.0
+    global_batch_size = 64
+
+    # Standard colocated rollout: 16 engines × 16 GPUs, avoiding PD KV transfer.
+    rollout_num_gpus_per_engine = 16
+    # Leave room for the co-located Megatron-to-HF weight sync TP all-gathers.
+    # Large individual tensors are sent zero-copy by the Modal runtime patch.
+    sglang_mem_fraction_static = 0.86
+    sglang_enable_dp_attention = True
+    sglang_ep_size = 16
+    sglang_dp_size = 16
+    sglang_moe_dense_tp_size = 1
+    sglang_enable_dp_lm_head = True
+    sglang_moe_a2a_backend = "none"
+    sglang_deepep_mode = None
+    sglang_page_size = 64
+    sglang_kv_cache_dtype = "fp8_e4m3"
+    sglang_nsa_decode_backend = "flashmla_kv"
+    sglang_nsa_prefill_backend = "flashmla_sparse"
+    sglang_attention_backend = "nsa"
+    sglang_cuda_graph_max_bs = 8
+    sglang_disable_overlap_schedule = True
+    sglang_max_running_requests = 512
+    sglang_watchdog_timeout = 3600
+    # Keep the initial Megatron-to-SGLang weight update under H100 memory
+    # pressure; EAGLE's draft model adds several resident GB per GPU.
+    sglang_speculative_algorithm = None
+    sglang_speculative_num_steps = None
+    sglang_speculative_eagle_topk = None
+    sglang_speculative_num_draft_tokens = None
+    sglang_speculative_draft_attention_backend = None
+
+    # ── Training ──────────────────────────────────────────────────────────────
+    tensor_model_parallel_size = 4
+    conversion_tensor_model_parallel_size = 4
+    conversion_pipeline_model_parallel_size = 8
+    sequence_parallel = True
+    pipeline_model_parallel_size = 8
+    decoder_first_pipeline_num_layers = 14
+    decoder_last_pipeline_num_layers = 16
+    context_parallel_size = 8
+    expert_model_parallel_size = 32
+    expert_tensor_parallel_size = 1
+    recompute_granularity = "full"
+    recompute_method = "uniform"
+    recompute_num_layers = 1
+    use_dynamic_batch_size = True
+    max_tokens_per_gpu = 4096
+    # Upstream uses 1024 for throughput, but with colocated SGLang the actor
+    # train step needs smaller packed-token microbatches to leave headroom for
+    # MoE and fused cross-entropy backward scratch/autotune allocations.
+    data_pad_size_multiplier = 64
+    log_probs_chunk_size = 16384
+    train_memory_margin_bytes = 0
+    attention_dropout = 0.0
+    hidden_dropout = 0.0
+    accumulate_allreduce_grads_in_fp32 = True
+    attention_softmax_in_fp32 = True
+    attention_backend = "flash"
+    moe_token_dispatcher_type = "alltoall"
+
+    # ── Algorithm ─────────────────────────────────────────────────────────────
+    advantage_estimator = "grpo"
+    kl_loss_coef = 0.0
+    kl_loss_type = "low_var_kl"
+    kl_coef = 0.0
+    entropy_coef = 0.0
+    eps_clip = 0.2
+    eps_clip_high = 0.28
+    use_tis = True
+    tis_clip_low = 0.5
+    tis_clip = 2.0
+
+    # ── Optimizer ─────────────────────────────────────────────────────────────
+    optimizer = "adam"
+    lr = 1e-6
+    lr_decay_style = "constant"
+    weight_decay = 0.1
+    adam_beta1 = 0.9
+    adam_beta2 = 0.98
+    optimizer_cpu_offload = True
+    overlap_cpu_optimizer_d2h_h2d = True
+    use_precision_aware_optimizer = True
+
+    # ── WandB ─────────────────────────────────────────────────────────────────
+    use_wandb = True
+    wandb_project = "slime-grpo"
+    wandb_group = "glm5.2-744b-a40b-dapo-math-32n"
+    disable_wandb_random_suffix = True
+
+    def download_data(self) -> None:
+        """Download DAPO-Math-17k from Hugging Face to the data volume."""
+        import os
+        from huggingface_hub import snapshot_download
+
+        os.makedirs(f"{DATA_PATH}/dapo-math-17k", exist_ok=True)
+        snapshot_download(
+            repo_id="zhuzilin/dapo-math-17k",
+            repo_type="dataset",
+            local_dir=f"{DATA_PATH}/dapo-math-17k",
+        )
+
+
+slime = _Slime()

--- a/slime/modal_helpers/convert_hf_to_torch_dist.py
+++ b/slime/modal_helpers/convert_hf_to_torch_dist.py
@@ -12,12 +12,52 @@ When SKIP_RELEASE_RENAME is unset this wrapper is a transparent pass-through.
 """
 
 import os
+import sys
+from pathlib import Path
 
 _UPSTREAM = "/root/slime/tools/convert_hf_to_torch_dist.py"
 
+_PACKAGE_PARENT = str(Path(__file__).resolve().parent.parent)
+if _PACKAGE_PARENT not in sys.path:
+    sys.path.insert(0, _PACKAGE_PARENT)
+
+with open(_UPSTREAM) as f:
+    _src = f.read()
+
+_src = _src.replace(
+    "import slime_plugins.mbridge  # noqa: F401\n",
+    "import slime_plugins.mbridge  # noqa: F401\n"
+    "from modal_helpers.runtime_patches import apply_modal_runtime_patches\n"
+    "apply_modal_runtime_patches()\n",
+)
+
+if os.environ.get("CONVERSION_DIST_TIMEOUT_MINUTES"):
+    _src = _src.replace(
+        "import torch.distributed as dist\n",
+        "import torch.distributed as dist\n"
+        "_modal_dist_timeout = __import__('datetime').timedelta("
+        "minutes=int(os.environ['CONVERSION_DIST_TIMEOUT_MINUTES']))\n"
+        "try:\n"
+        "    import torch.distributed.constants as _modal_dist_constants\n"
+        "    import torch.distributed.distributed_c10d as _modal_dist_c10d\n"
+        "    _modal_dist_constants.default_pg_timeout = _modal_dist_timeout\n"
+        "    _modal_dist_c10d.default_pg_timeout = _modal_dist_timeout\n"
+        "except Exception:\n"
+        "    pass\n"
+        "_modal_original_new_group = dist.new_group\n"
+        "def _modal_new_group_with_timeout(*args, **kwargs):\n"
+        "    kwargs.setdefault('timeout', _modal_dist_timeout)\n"
+        "    return _modal_original_new_group(*args, **kwargs)\n"
+        "dist.new_group = _modal_new_group_with_timeout\n",
+    )
+    _src = _src.replace(
+        'dist.init_process_group(\n        backend="nccl",',
+        "dist.init_process_group(\n"
+        "        timeout=_modal_dist_timeout,\n"
+        '        backend="nccl",',
+    )
+
 if os.environ.get("SKIP_RELEASE_RENAME"):
-    with open(_UPSTREAM) as f:
-        _src = f.read()
     _src = _src.replace(
         "shutil.move(source_dir, target_dir)",
         "pass  # SKIP_RELEASE_RENAME",
@@ -28,4 +68,4 @@ if os.environ.get("SKIP_RELEASE_RENAME"):
     )
     exec(compile(_src, _UPSTREAM, "exec"))
 else:
-    exec(compile(open(_UPSTREAM).read(), _UPSTREAM, "exec"))
+    exec(compile(_src, _UPSTREAM, "exec"))

--- a/slime/modal_helpers/run_with_runtime_patches.py
+++ b/slime/modal_helpers/run_with_runtime_patches.py
@@ -1,0 +1,27 @@
+"""Run a Python script after applying Modal runtime patches."""
+
+from __future__ import annotations
+
+import runpy
+import sys
+from pathlib import Path
+
+_PACKAGE_PARENT = str(Path(__file__).resolve().parent.parent)
+if _PACKAGE_PARENT not in sys.path:
+    sys.path.insert(0, _PACKAGE_PARENT)
+
+from modal_helpers.runtime_patches import apply_modal_runtime_patches
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        raise SystemExit("usage: python -m modal_helpers.run_with_runtime_patches SCRIPT [ARGS...]")
+
+    script = sys.argv[1]
+    sys.argv = [script, *sys.argv[2:]]
+    apply_modal_runtime_patches()
+    runpy.run_path(script, run_name="__main__")
+
+
+if __name__ == "__main__":
+    main()

--- a/slime/modal_helpers/runtime_patches.py
+++ b/slime/modal_helpers/runtime_patches.py
@@ -1,0 +1,662 @@
+"""Runtime compatibility patches for Modal-hosted SLIME jobs."""
+
+from __future__ import annotations
+
+import io
+import os
+
+
+def _env_enabled(name: str, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.lower() not in {"0", "false", "no", "off", ""}
+
+
+def _log_patch(message: str) -> None:
+    if _env_enabled("MODAL_RUNTIME_PATCHES_LOG", default=True):
+        print(f"Modal runtime patch: {message}", flush=True)
+
+
+def _clear_dsa_context_parallel_hint(config, source: str) -> None:
+    if (
+        getattr(config, "experimental_attention_variant", None) == "dsa"
+        and getattr(config, "context_parallel_size", 1) != 1
+    ):
+        config.experimental_attention_variant = None
+        _log_patch(f"cleared DSAttention CP guard before {source}")
+
+
+def _patch_glm_moe_dsa_hf_config(hf_config) -> None:
+    if getattr(hf_config, "model_type", None) != "glm_moe_dsa":
+        return
+
+    override = os.environ.get("GLM_MOE_DSA_QK_POS_EMB_HEAD_DIM", "64")
+    try:
+        qk_pos_emb_head_dim = int(override)
+    except ValueError:
+        return
+
+    current = getattr(hf_config, "qk_rope_head_dim", None)
+    if current == qk_pos_emb_head_dim:
+        return
+
+    hf_config.qk_rope_head_dim = qk_pos_emb_head_dim
+    _log_patch(
+        "corrected GLM qk_rope_head_dim "
+        f"from {current} to {qk_pos_emb_head_dim}"
+    )
+
+
+def _patch_glm_moe_dsa_bridge_config(config, source: str) -> None:
+    override = os.environ.get("GLM_MOE_DSA_QK_POS_EMB_HEAD_DIM", "64")
+    try:
+        qk_pos_emb_head_dim = int(override)
+    except ValueError:
+        return
+
+    if getattr(config, "qk_pos_emb_head_dim", None) == qk_pos_emb_head_dim:
+        return
+
+    # GLM-5.2-FP8's HF config reports qk_rope_head_dim=192, but its weights
+    # encode qk_nope=192 and qk_rope=64:
+    #   q_b_proj: 64 * (192 + 64)
+    #   kv_a_proj_with_mqa: 512 + 64
+    # Patch the deferred bridge config object because the training load path
+    # does not necessarily use Slime's plugin bridge wrapper.
+    if not (
+        getattr(config, "hidden_size", None) == 6144
+        and getattr(config, "num_layers", None) == 78
+        and getattr(config, "kv_lora_rank", None) == 512
+        and getattr(config, "qk_head_dim", None) == 192
+    ):
+        return
+
+    current = getattr(config, "qk_pos_emb_head_dim", None)
+    config.qk_pos_emb_head_dim = qk_pos_emb_head_dim
+    _log_patch(
+        "corrected GLM bridge qk_pos_emb_head_dim "
+        f"from {current} to {qk_pos_emb_head_dim} before {source}"
+    )
+
+
+def _patch_fp8_dequant_cuda() -> None:
+    if not _env_enabled("PATCH_FP8_DEQUANT_CUDA", default=True):
+        return
+
+    try:
+        import torch
+        import mbridge.models.ext.deepseek_v3.dequant_fp8_safetensor_io as fp8_io
+    except Exception:
+        return
+
+    original = fp8_io.weight_dequant
+    if getattr(original, "_modal_cuda_dequant_patch", False):
+        return
+
+    def weight_dequant_cuda(weight, scale_inv, *args, **kwargs):
+        device = torch.device("cuda", torch.cuda.current_device())
+        weight = weight.to(device=device, non_blocking=True)
+        scale_inv = scale_inv.to(device=device, non_blocking=True)
+        return original(weight.contiguous(), scale_inv.contiguous(), *args, **kwargs)
+
+    weight_dequant_cuda._modal_cuda_dequant_patch = True
+    fp8_io.weight_dequant = weight_dequant_cuda
+
+
+def _patch_dcp_thread_count() -> None:
+    thread_count = os.environ.get("MODAL_DCP_THREAD_COUNT")
+    if not thread_count:
+        return
+
+    try:
+        forced_thread_count = int(thread_count)
+    except ValueError:
+        return
+    if forced_thread_count < 1:
+        return
+
+    try:
+        import megatron.core.dist_checkpointing.strategies.filesystem_async as fs_async
+    except Exception:
+        return
+
+    writer_cls = fs_async.FileSystemWriterAsync
+    if getattr(writer_cls, "_modal_thread_count_patch", False):
+        return
+
+    original_init = writer_cls.__init__
+
+    def init_with_thread_count(self, path, *args, **kwargs):
+        kwargs["thread_count"] = forced_thread_count
+        return original_init(self, path, *args, **kwargs)
+
+    init_with_thread_count._modal_original_init = original_init
+    writer_cls.__init__ = init_with_thread_count
+    writer_cls._modal_thread_count_patch = True
+
+
+def _patch_dcp_buffered_torch_save() -> None:
+    if not _env_enabled("MODAL_DCP_BUFFERED_TORCH_SAVE"):
+        return
+
+    try:
+        import torch
+        import torch.distributed.checkpoint.filesystem as dcp_fs
+        import megatron.core.dist_checkpointing.strategies.filesystem_async as fs_async
+        from torch.distributed.checkpoint.planner import WriteItemType
+        from torch.distributed.checkpoint.storage import WriteResult
+    except Exception:
+        return
+
+    if getattr(fs_async, "_modal_buffered_torch_save_patch", False):
+        return
+
+    original_write_item = fs_async._write_item
+
+    def write_item_buffered(
+        transforms,
+        stream,
+        data,
+        write_item,
+        storage_key,
+        serialization_format=dcp_fs.SerializationFormat.TORCH_SAVE,
+    ):
+        if (
+            serialization_format != dcp_fs.SerializationFormat.TORCH_SAVE
+            or write_item.type == WriteItemType.BYTE_IO
+            or not isinstance(data, torch.Tensor)
+            or data.device.type != "cpu"
+        ):
+            return original_write_item(
+                transforms,
+                stream,
+                data,
+                write_item,
+                storage_key,
+                serialization_format=serialization_format,
+            )
+
+        offset = stream.tell()
+        transform_to, transform_descriptors = transforms.transform_save_stream(
+            write_item, stream
+        )
+        try:
+            buffer = io.BytesIO()
+            torch.save(data, buffer)
+            transform_to.write(buffer.getbuffer())
+            transform_to.close()
+        except Exception:
+            try:
+                transform_to.close()
+            except Exception:
+                pass
+            raise
+
+        length = stream.tell() - offset
+        if len(transform_descriptors) == 0:
+            transform_descriptors = None
+
+        return WriteResult(
+            index=write_item.index,
+            size_in_bytes=length,
+            storage_data=dcp_fs._StorageInfo(
+                storage_key,
+                offset,
+                length,
+                transform_descriptors=transform_descriptors,
+            ),
+        )
+
+    fs_async._write_item = write_item_buffered
+    fs_async._modal_buffered_torch_save_patch = True
+
+
+def _patch_flattened_tensor_bucket_single_tensor_zero_copy() -> None:
+    if not _env_enabled("PATCH_SINGLE_TENSOR_BUCKET_ZERO_COPY", default=True):
+        return
+
+    try:
+        import torch
+        import sglang.srt.weight_sync.tensor_bucket as tensor_bucket
+    except Exception:
+        return
+
+    bucket_cls = tensor_bucket.FlattenedTensorBucket
+    if getattr(bucket_cls, "_modal_single_tensor_zero_copy_patch", False):
+        return
+
+    original_init = bucket_cls.__init__
+    metadata_cls = tensor_bucket.FlattenedTensorMetadata
+
+    def init_single_tensor_zero_copy(
+        self,
+        named_tensors=None,
+        flattened_tensor=None,
+        metadata=None,
+    ):
+        if named_tensors is None or len(named_tensors) != 1:
+            return original_init(
+                self,
+                named_tensors=named_tensors,
+                flattened_tensor=flattened_tensor,
+                metadata=metadata,
+            )
+
+        name, tensor = named_tensors[0]
+        flattened = tensor.flatten().view(torch.uint8)
+        numel = flattened.numel()
+        self.metadata = [
+            metadata_cls(
+                name=name,
+                shape=tensor.shape,
+                dtype=tensor.dtype,
+                start_idx=0,
+                end_idx=numel,
+                numel=numel,
+            )
+        ]
+        self.flattened_tensor = flattened
+
+    bucket_cls.__init__ = init_single_tensor_zero_copy
+    bucket_cls._modal_single_tensor_zero_copy_patch = True
+    _log_patch("patched FlattenedTensorBucket single-tensor zero-copy path")
+
+
+def _patch_dsa_kv_pool_cpu_copy_signature() -> None:
+    if not _env_enabled("PATCH_DSA_KV_POOL_MAMBA_INDICES", default=True):
+        return
+
+    try:
+        import importlib
+        import inspect
+    except Exception:
+        return
+
+    module_names = (
+        "sglang.srt.mem_cache.memory_pool",
+        "sglang.srt.mem_cache.allocator.base",
+        "sglang.srt.mem_cache.allocator.paged",
+    )
+    patched = []
+
+    def wrap_method(pool_cls, method_name: str) -> None:
+        original = getattr(pool_cls, method_name, None)
+        if original is None or getattr(original, "_modal_mamba_indices_patch", False):
+            return
+
+        try:
+            if "mamba_indices" in inspect.signature(original).parameters:
+                return
+        except Exception:
+            pass
+
+        def method_ignoring_mamba_indices(
+            self, *args, __original=original, mamba_indices=None, **kwargs
+        ):
+            return __original(self, *args, **kwargs)
+
+        method_ignoring_mamba_indices._modal_mamba_indices_patch = True
+        method_ignoring_mamba_indices._modal_original = original
+        setattr(pool_cls, method_name, method_ignoring_mamba_indices)
+        patched.append(f"{pool_cls.__module__}.{pool_cls.__name__}.{method_name}")
+
+    for module_name in module_names:
+        try:
+            module = importlib.import_module(module_name)
+        except Exception:
+            continue
+
+        for class_name, pool_cls in vars(module).items():
+            if not isinstance(pool_cls, type):
+                continue
+            if class_name not in {"DSATokenToKVPool", "NSATokenToKVPool"}:
+                continue
+            wrap_method(pool_cls, "get_cpu_copy")
+            wrap_method(pool_cls, "load_cpu_copy")
+
+    if patched:
+        _log_patch(
+            "patched KV pool CPU-copy mamba_indices compatibility for "
+            + ", ".join(patched)
+        )
+
+
+def _patch_glm_moe_dsa_bridge_context_parallel() -> None:
+    """Let Slime's GLM5 DSA spec own CP instead of Megatron-Core DSAttention."""
+    if not _env_enabled("PATCH_GLM_MOE_DSA_CP", default=True):
+        return
+
+    _patch_megatron_core_dsa_context_parallel_guard()
+    _patch_megatron_bridge_dsa_context_parallel_guard()
+
+    try:
+        import slime_plugins.mbridge.deepseek_v32 as deepseek_v32
+    except Exception:
+        return
+
+    bridge_cls = deepseek_v32.DeepseekV32Bridge
+    if getattr(bridge_cls, "_modal_glm_moe_dsa_cp_patch", False):
+        return
+
+    original_build_config = bridge_cls._build_config
+
+    def build_config_without_core_dsa(self, *args, **kwargs):
+        _patch_glm_moe_dsa_hf_config(self.hf_config)
+        config = original_build_config(self, *args, **kwargs)
+        if getattr(self.hf_config, "model_type", None) == "glm_moe_dsa":
+            # Slime's glm5 spec replaces the layer attention module with its own
+            # DSAMLASelfAttention. Leaving this bridge flag as "dsa" sends the
+            # provider through Megatron-Core's DSAttention validation, which
+            # currently rejects context parallelism before Slime can replace it.
+            _clear_dsa_context_parallel_hint(config, "DeepseekV32Bridge._build_config")
+        return config
+
+    bridge_cls._build_config = build_config_without_core_dsa
+    bridge_cls._modal_glm_moe_dsa_cp_patch = True
+    _log_patch("patched DeepseekV32Bridge._build_config")
+
+
+def _patch_megatron_bridge_dsa_context_parallel_guard() -> None:
+    try:
+        import megatron.bridge.models.transformer_config as bridge_transformer_config
+    except Exception:
+        return
+
+    for class_name in ("TransformerConfig", "MLATransformerConfig"):
+        config_cls = getattr(bridge_transformer_config, class_name, None)
+        if (
+            config_cls is None
+            or config_cls.__dict__.get("_modal_glm_moe_dsa_finalize_patch", False)
+        ):
+            continue
+
+        original_finalize = config_cls.finalize
+
+        def finalize_without_core_dsa_cp_assertion(
+            self,
+            *args,
+            __original_finalize=original_finalize,
+            __class_name=class_name,
+            **kwargs,
+        ):
+            _patch_glm_moe_dsa_bridge_config(
+                self,
+                f"megatron.bridge.models.transformer_config.{__class_name}.finalize",
+            )
+            _clear_dsa_context_parallel_hint(
+                self,
+                f"megatron.bridge.models.transformer_config.{__class_name}.finalize",
+            )
+            return __original_finalize(self, *args, **kwargs)
+
+        config_cls.finalize = finalize_without_core_dsa_cp_assertion
+        config_cls._modal_glm_moe_dsa_finalize_patch = True
+        _log_patch(f"patched bridge {class_name}.finalize")
+
+
+def _patch_megatron_core_dsa_context_parallel_guard() -> None:
+    try:
+        import megatron.core.transformer.transformer_config as transformer_config
+    except Exception:
+        return
+
+    for class_name in ("TransformerConfig", "MLATransformerConfig"):
+        config_cls = getattr(transformer_config, class_name, None)
+        if (
+            config_cls is None
+            or config_cls.__dict__.get("_modal_glm_moe_dsa_cp_patch", False)
+        ):
+            continue
+
+        original_post_init = config_cls.__post_init__
+
+        def post_init_without_core_dsa_cp_assertion(
+            self, __original_post_init=original_post_init, __class_name=class_name
+        ):
+            # GLM-5 uses Slime's DSAMLASelfAttention replacement, which handles
+            # context parallelism itself. Megatron-Core validates its own DSA
+            # path before Slime swaps the module, so clear this bridge hint here.
+            _clear_dsa_context_parallel_hint(
+                self,
+                f"megatron.core.transformer.transformer_config.{__class_name}.__post_init__",
+            )
+            return __original_post_init(self)
+
+        config_cls.__post_init__ = post_init_without_core_dsa_cp_assertion
+        config_cls._modal_glm_moe_dsa_cp_patch = True
+        _log_patch(f"patched Megatron-Core {class_name}.__post_init__")
+
+
+def _patch_slime_megatron_actor_init() -> None:
+    if not _env_enabled("PATCH_SLIME_MEGATRON_ACTOR_INIT", default=True):
+        return
+
+    try:
+        import slime.backends.megatron_utils.actor as actor_module
+    except Exception:
+        return
+
+    actor_cls = actor_module.MegatronTrainRayActor
+    if getattr(actor_cls, "_modal_runtime_patches_init_patch", False):
+        return
+
+    original_init = actor_cls.init
+
+    def init_with_modal_runtime_patches(self, *args, **kwargs):
+        apply_modal_runtime_patches()
+        return original_init(self, *args, **kwargs)
+
+    actor_cls.init = init_with_modal_runtime_patches
+    actor_cls._modal_runtime_patches_init_patch = True
+    _log_patch("patched MegatronTrainRayActor.init")
+
+
+def _patch_megatron_allgather_cp_rope() -> None:
+    if not _env_enabled("PATCH_MEGATRON_ALLGATHER_CP_ROPE"):
+        return
+
+    try:
+        import torch
+        import megatron.core.models.common.embeddings.rope_utils as rope_utils
+    except Exception:
+        return
+
+    if getattr(rope_utils, "_modal_allgather_cp_rope_patch", False):
+        return
+
+    original_thd = rope_utils._apply_rotary_pos_emb_thd
+    apply_bshd = rope_utils._apply_rotary_pos_emb_bshd
+
+    def slice_freqs(
+        freqs,
+        start: int,
+        length: int,
+        fallback_offset: int,
+        original_total: int,
+    ):
+        if length <= 0:
+            return freqs.narrow(0, 0, 0)
+
+        freq_len = int(freqs.size(0))
+        if freq_len == original_total and start < freq_len:
+            end = min(start + length, freq_len)
+            piece = freqs[start:end]
+        else:
+            end = min(fallback_offset + length, freq_len)
+            piece = freqs[fallback_offset:end]
+
+        missing = length - int(piece.size(0))
+        if missing <= 0:
+            return piece
+
+        # Missing positions are synthetic pad tokens. Reusing the final rotary
+        # row keeps the tensor shape valid while masked pad tokens contribute no
+        # training loss.
+        filler = freqs[-1:].expand(missing, *freqs.shape[1:])
+        return torch.cat([piece, filler], dim=0)
+
+    def thd_allgather_cp_rope(
+        t,
+        cu_seqlens,
+        freqs,
+        rotary_interleaved=False,
+        multi_latent_attention=False,
+        mscale=1.0,
+        cp_group=None,
+        **kwargs,
+    ):
+        if cp_group is None or cu_seqlens is None:
+            return original_thd(
+                t,
+                cu_seqlens,
+                freqs,
+                rotary_interleaved=rotary_interleaved,
+                multi_latent_attention=multi_latent_attention,
+                mscale=mscale,
+                cp_group=cp_group,
+                **kwargs,
+            )
+
+        cp_size = cp_group.size()
+        if cp_size <= 1:
+            return original_thd(
+                t,
+                cu_seqlens,
+                freqs,
+                rotary_interleaved=rotary_interleaved,
+                multi_latent_attention=multi_latent_attention,
+                mscale=mscale,
+                cp_group=cp_group,
+                **kwargs,
+            )
+
+        local_len = int(t.size(0))
+        global_len = local_len * cp_size
+        global_pad_limit = int(
+            os.environ.get("PATCH_MEGATRON_ALLGATHER_CP_ROPE_MAX_PAD_TOKENS", "8192")
+        )
+
+        try:
+            boundaries = [int(x) for x in cu_seqlens.detach().cpu().tolist()]
+        except Exception:
+            return original_thd(
+                t,
+                cu_seqlens,
+                freqs,
+                rotary_interleaved=rotary_interleaved,
+                multi_latent_attention=multi_latent_attention,
+                mscale=mscale,
+                cp_group=cp_group,
+                **kwargs,
+            )
+
+        if not boundaries:
+            return original_thd(
+                t,
+                cu_seqlens,
+                freqs,
+                rotary_interleaved=rotary_interleaved,
+                multi_latent_attention=multi_latent_attention,
+                mscale=mscale,
+                cp_group=cp_group,
+                **kwargs,
+            )
+
+        original_total = int(cu_seqlens[-1].item())
+
+        if boundaries[-1] < global_len:
+            pad = global_len - boundaries[-1]
+            if pad > global_pad_limit:
+                return original_thd(
+                    t,
+                    cu_seqlens,
+                    freqs,
+                    rotary_interleaved=rotary_interleaved,
+                    multi_latent_attention=multi_latent_attention,
+                    mscale=mscale,
+                    cp_group=cp_group,
+                    **kwargs,
+                )
+            boundaries.append(global_len)
+        elif boundaries[-1] > global_len:
+            return original_thd(
+                t,
+                cu_seqlens,
+                freqs,
+                rotary_interleaved=rotary_interleaved,
+                multi_latent_attention=multi_latent_attention,
+                mscale=mscale,
+                cp_group=cp_group,
+                **kwargs,
+            )
+
+        cp_rank = cp_group.rank()
+        local_start = cp_rank * local_len
+        local_end = local_start + local_len
+        pieces = []
+
+        for seq_start, seq_end in zip(boundaries, boundaries[1:], strict=False):
+            if seq_end <= seq_start:
+                continue
+            overlap_start = max(local_start, seq_start)
+            overlap_end = min(local_end, seq_end)
+            if overlap_start >= overlap_end:
+                continue
+            pieces.append(
+                slice_freqs(
+                    freqs,
+                    overlap_start,
+                    overlap_end - overlap_start,
+                    overlap_start - seq_start,
+                    original_total,
+                )
+            )
+
+        if not pieces:
+            return original_thd(
+                t,
+                cu_seqlens,
+                freqs,
+                rotary_interleaved=rotary_interleaved,
+                multi_latent_attention=multi_latent_attention,
+                mscale=mscale,
+                cp_group=cp_group,
+                **kwargs,
+            )
+
+        freqs_packed = torch.cat(pieces, dim=0)
+        if int(freqs_packed.size(0)) < local_len:
+            missing = local_len - int(freqs_packed.size(0))
+            freqs_packed = torch.cat(
+                [freqs_packed, freqs[-1:].expand(missing, *freqs.shape[1:])],
+                dim=0,
+            )
+        elif int(freqs_packed.size(0)) > local_len:
+            freqs_packed = freqs_packed[:local_len]
+
+        return apply_bshd(
+            t.unsqueeze(1),
+            freqs_packed,
+            rotary_interleaved=rotary_interleaved,
+            multi_latent_attention=multi_latent_attention,
+            mscale=mscale,
+        ).squeeze(1)
+
+    thd_allgather_cp_rope._modal_allgather_cp_rope_patch = True
+    thd_allgather_cp_rope._modal_original = original_thd
+    rope_utils._apply_rotary_pos_emb_thd = thd_allgather_cp_rope
+    rope_utils._modal_allgather_cp_rope_patch = True
+    _log_patch("patched Megatron THD RoPE for allgather-CP layout")
+
+
+def apply_modal_runtime_patches() -> None:
+    """Apply patches selected by environment variables."""
+    _patch_fp8_dequant_cuda()
+    _patch_flattened_tensor_bucket_single_tensor_zero_copy()
+    _patch_dsa_kv_pool_cpu_copy_signature()
+    _patch_glm_moe_dsa_bridge_context_parallel()
+    _patch_megatron_allgather_cp_rope()
+    _patch_slime_megatron_actor_init()
+    _patch_dcp_thread_count()
+    _patch_dcp_buffered_torch_save()

--- a/slime/modal_helpers/sitecustomize.py
+++ b/slime/modal_helpers/sitecustomize.py
@@ -1,0 +1,26 @@
+"""Autoload Modal runtime patches in Ray worker Python processes."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def _enabled(name: str, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.lower() not in {"0", "false", "no", "off", ""}
+
+
+if _enabled("MODAL_RUNTIME_PATCHES_AUTOAPPLY"):
+    try:
+        if "/root" not in sys.path:
+            sys.path.insert(0, "/root")
+        from modal_helpers.runtime_patches import apply_modal_runtime_patches
+
+        apply_modal_runtime_patches()
+    except Exception as exc:
+        if _enabled("MODAL_RUNTIME_PATCHES_STRICT"):
+            raise
+        print(f"Modal runtime patch autoload skipped: {exc!r}")

--- a/slime/modal_helpers/utils.py
+++ b/slime/modal_helpers/utils.py
@@ -43,8 +43,14 @@ def get_checkpoint_conversion_policy(slime_cfg) -> tuple[int, int, list[str]]:
     """Return (num_nodes, nproc_per_node, extra_args) for checkpoint conversion."""
     gpus_per_node = getattr(slime_cfg, "actor_num_gpus_per_node", 8)
     actor_nodes = getattr(slime_cfg, "actor_num_nodes", 1)
-    tp = getattr(slime_cfg, "tensor_model_parallel_size", 1)
-    pp = getattr(slime_cfg, "pipeline_model_parallel_size", 1)
+    tp = (
+        getattr(slime_cfg, "conversion_tensor_model_parallel_size", None)
+        or getattr(slime_cfg, "tensor_model_parallel_size", 1)
+    )
+    pp = (
+        getattr(slime_cfg, "conversion_pipeline_model_parallel_size", None)
+        or getattr(slime_cfg, "pipeline_model_parallel_size", 1)
+    )
 
     world_size = tp * pp if (tp > 1 or pp > 1) else gpus_per_node
     max_world_size = actor_nodes * gpus_per_node
@@ -156,10 +162,13 @@ def build_train_cmd(slime_cfg, slime_root: str) -> str:
     train_script = (
         f"{slime_root}/{'train_async.py' if slime_cfg.async_mode else 'train.py'}"
     )
+    python_entrypoint = (
+        f"python3 /root/modal_helpers/run_with_runtime_patches.py {train_script}"
+    )
     if slime_cfg.slime_model_script:
         inner = (
             f"source {slime_root}/{slime_cfg.slime_model_script} && "
-            f"python3 {train_script} ${{MODEL_ARGS[@]}} {shlex.join(slime_cfg.cli_args())}"
+            f"{python_entrypoint} ${{MODEL_ARGS[@]}} {shlex.join(slime_cfg.cli_args())}"
         )
         return f"bash -c {shlex.quote(inner)}"
-    return f"python3 {train_script} {shlex.join(slime_cfg.cli_args())}"
+    return f"{python_entrypoint} {shlex.join(slime_cfg.cli_args())}"

--- a/slime/modal_train.py
+++ b/slime/modal_train.py
@@ -29,6 +29,9 @@ image = (
     .entrypoint([])
     .add_local_python_source("configs", copy=True)
     .add_local_python_source("modal_helpers", copy=True)
+    .add_local_file(
+        "slime/modal_helpers/sitecustomize.py", "/root/sitecustomize.py", copy=True
+    )
 )
 if modal_cfg:
     for patch in modal_cfg.patch_files:
@@ -41,6 +44,11 @@ if modal_cfg:
             remote_path=SLIME_ROOT,
             copy=True,
             ignore=["**/__pycache__", "**/*.pyc", "**/.git", "**/.venv"],
+        )
+        image = image.add_local_file(
+            "slime/modal_helpers/sitecustomize.py",
+            f"{SLIME_ROOT}/sitecustomize.py",
+            copy=True,
         )
     if modal_cfg.image_run_commands:
         image = image.run_commands(*modal_cfg.image_run_commands)
@@ -75,6 +83,12 @@ app = modal.App(experiment)
 
 RAY_PORT = 6379
 RAY_DASHBOARD_PORT = 8265
+
+
+def efa_experimental_options():
+    if modal_cfg and getattr(modal_cfg, "efa_enabled", True):
+        return {"efa_enabled": True}
+    return None
 
 
 def run_config_hook(experiment: str, hook_name: str, mounted_volumes) -> None:
@@ -157,10 +171,17 @@ def post_process_data(experiment: str = os.environ.get("EXPERIMENT_CONFIG", ""))
 
 @app.function(
     image=image,
-    gpu=f"{modal_cfg.gpu}:{slime_cfg.actor_num_gpus_per_node}" if modal_cfg else None,
+    gpu=(
+        f"{modal_cfg.conversion_gpu or modal_cfg.gpu}:{slime_cfg.actor_num_gpus_per_node}"
+        if modal_cfg
+        else None
+    ),
+    memory=modal_cfg.memory if modal_cfg and modal_cfg.memory else None,
+    cloud=modal_cfg.cloud if modal_cfg and modal_cfg.cloud else None,
+    region=modal_cfg.region if modal_cfg and modal_cfg.region else None,
     volumes=modal_volumes,
     timeout=4 * 60 * 60,
-    experimental_options={"efa_enabled": True},
+    experimental_options=efa_experimental_options(),
 )
 @(
     modal.experimental.clustered(
@@ -221,6 +242,9 @@ def convert_hf_to_megatron_checkpoint(
     env = {**os.environ, **slime_cfg.environment}
     if num_nodes > 1:
         env["SKIP_RELEASE_RENAME"] = "1"
+        env.setdefault("CONVERSION_DIST_TIMEOUT_MINUTES", "60")
+        env.setdefault("MODAL_DCP_BUFFERED_TORCH_SAVE", "1")
+        env.setdefault("MODAL_DCP_THREAD_COUNT", "1")
 
     print(
         f"Conversion layout for {experiment!r}: nodes={num_nodes}, "
@@ -247,7 +271,7 @@ def convert_hf_to_megatron_checkpoint(
     volumes=modal_volumes,
     secrets=[modal.Secret.from_name("wandb-secret")],
     timeout=24 * 60 * 60,
-    experimental_options={"efa_enabled": True},
+    experimental_options=efa_experimental_options(),
 )
 @(
     modal.experimental.clustered(slime_cfg.total_nodes(), rdma=True)
@@ -290,19 +314,20 @@ async def train(experiment: str = os.environ.get("EXPERIMENT_CONFIG", "")):
     start_ray_head(my_ip, n_nodes)
     prepare_slime_config(slime_cfg, tempfile.mkdtemp())
 
+    cmd = build_train_cmd(slime_cfg, SLIME_ROOT)
+    no_proxy = f"localhost,127.0.0.1,0.0.0.0,{master_addr},10.0.0.0/8,100.64.0.0/10"
+    env_vars = {
+        "no_proxy": no_proxy,
+        "NO_PROXY": no_proxy,
+        "MASTER_ADDR": master_addr,
+        "MODAL_RUNTIME_PATCHES_AUTOAPPLY": "1",
+        **slime_cfg.environment,
+    }
     if (wandb_key := os.environ.get("WANDB_API_KEY", "")) and getattr(
         slime_cfg, "use_wandb", False
     ):
-        slime_cfg.wandb_key = wandb_key
-
-    cmd = build_train_cmd(slime_cfg, SLIME_ROOT)
-    runtime_env = {
-        "env_vars": {
-            "no_proxy": f"127.0.0.1,{master_addr}",
-            "MASTER_ADDR": master_addr,
-            **slime_cfg.environment,
-        }
-    }
+        env_vars["WANDB_API_KEY"] = wandb_key
+    runtime_env = {"env_vars": env_vars}
 
     client = JobSubmissionClient("http://127.0.0.1:8265")
     job_id = client.submit_job(entrypoint=cmd, runtime_env=runtime_env)
@@ -311,7 +336,13 @@ async def train(experiment: str = os.environ.get("EXPERIMENT_CONFIG", "")):
     mode = "async" if slime_cfg.async_mode else "sync"
     print(f"Job submitted: {job_id}")
     print(f"Training {experiment:<40} {nodes} node(s) × {gpu}  ({mode})")
-    print(f"Command: {cmd}, runtime_env: {runtime_env}")
+    printable_runtime_env = {
+        "env_vars": {
+            key: ("[REDACTED]" if key == "WANDB_API_KEY" else value)
+            for key, value in env_vars.items()
+        }
+    }
+    print(f"Command: {cmd}, runtime_env: {printable_runtime_env}")
 
     async with modal.forward(RAY_DASHBOARD_PORT) as tunnel:
         print(f"Ray dashboard: {tunnel.url}")


### PR DESCRIPTION
## Summary

Adds a Modal/SLIME configuration and runtime support needed to run GLM-5.2-744B-A40B GRPO on a 32-node H100 allocation.

The working path uses colocated SGLang rollout engines instead of PD disaggregation because the available Modal/AWS transfer paths were not viable for this setup: Mooncake TCP failed CUDA buffer copies, NIXL/libfabric needed unavailable EFA memory-registration privileges, and NIXL/UCX only exposed loopback to the plugin.

## Changes

- Add `glm52_744b_a40b` experiment config for 32 H100 nodes, FP8 GLM-5.2, DAPO-Math, colocated rollout, EFA disabled, and the validated memory settings.
- Add Modal runtime patches for GLM bridge config fixes, Megatron allgather-CP RoPE handling, SGLang KV CPU-copy compatibility, and the single-tensor weight-update path.
- Add helper wrappers so runtime patches are applied consistently inside Modal workers.
- Make Modal EFA experimental options conditional and add network diagnostics for Modal/Ray/NIXL/EFA debugging.
- Adjust checkpoint/launcher helpers used by the GLM run.

## Validation

- `PYTHONPATH=slime uv run python -c "from configs.glm52_744b_a40b import slime, modal; ..."`
  - `rollout_max_response_len 1024`
  - `max_tokens_per_gpu 4096`
  - `data_pad_size_multiplier 64`
  - `efa_enabled False`
- `uv run python -m py_compile` on all changed Python files.
- Live Modal run on 32 H100 nodes completed a full step:
  - app `ap-FhbQwfQSx1MpdtFmgeE7dL`
  - W&B run `q5nwqqfd`
  - initial `update_weights` completed in `7429.1s`
  - rollout completed `64/64`, response length `1024`, rollout time `75.38s`
  - actor train completed `3/3` microbatches without the previous RoPE, MoE, or fused CE OOM failures
  - step `0` metrics logged successfully
